### PR TITLE
Fix the services typo in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: go
 go:
   - 1.14.x
-service:
+services:
   - docker
 install:
   - make travis


### PR DESCRIPTION
Change the configuration:
```
service:
  - docker
```
to
```
services:
  - docker
```

If using the old configuration, the docker service won't be enabled and startup.

Then the kind create cluster command will report failure because the docker is not started up:
```
# Creating a new Kubernetes cluster...
+kind create cluster
ERROR: failed to list clusters: command "docker ps -q -a --no-trunc --filter label=io.x-k8s.kind.cluster=kind --format '{{.Names}}'" failed with error: exit status 1
```

So fix to the correct format which follows by:
https://docs.travis-ci.com/user/database-setup/