### PR TITLE
Add unit test for getCustomTaskRun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ tags
 .vscode/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+# JetBrains IDE config
+.idea

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -8,7 +8,7 @@ import (
 // BuildSpec defines the desired state of Build
 type BuildSpec struct {
 
-	// Source refers to the Git repository constaining the
+	// Source refers to the Git repository containing the
 	// source code to be built.
 	Source GitSource `json:"source"`
 

--- a/pkg/controller/build/credential_test.go
+++ b/pkg/controller/build/credential_test.go
@@ -20,7 +20,6 @@ func TestApplyCredentials(t *testing.T) {
 		args args
 		want *corev1.ServiceAccount
 	}{
-
 		{
 			"secrets were not present",
 			args{

--- a/pkg/controller/build/generate_tekton.go
+++ b/pkg/controller/build/generate_tekton.go
@@ -16,6 +16,8 @@ import (
 
 const (
 	pipelineServiceAccountName = "pipeline"
+	inputImageResourceName    = "source"
+	inputImageResourceURL     = "url"
 	inputParamBuilderImage     = "BUILDER_IMAGE"
 	inputParamDockerfile       = "DOCKERFILE"
 	inputParamPathContext      = "PATH_CONTEXT"
@@ -86,7 +88,7 @@ func getCustomTask(buildInstance *buildv1alpha1.Build, buildStrategyInstance *bu
 				Resources: []taskv1.TaskResource{
 					{
 						ResourceDeclaration: taskv1.ResourceDeclaration{
-							Name: "source",
+							Name: inputImageResourceName,
 							Type: taskv1.PipelineResourceTypeGit,
 						},
 					},
@@ -174,12 +176,12 @@ func getCustomTaskRun(buildInstance *buildv1alpha1.Build, buildStrategyInstance 
 				Resources: []taskv1.TaskResourceBinding{
 					{
 						PipelineResourceBinding: taskv1.PipelineResourceBinding{
-							Name: "source",
+							Name: inputImageResourceName,
 							ResourceSpec: &taskv1.PipelineResourceSpec{
 								Type: taskv1.PipelineResourceTypeGit,
 								Params: []taskv1.ResourceParam{
 									{
-										Name:  "url",
+										Name:  inputImageResourceURL,
 										Value: buildInstance.Spec.Source.URL,
 									},
 								},


### PR DESCRIPTION
Hi,

There is no unit test for the `getCustomTaskRun` function in `controller/build/generate_tekton.go`

I added a unit test to make go coverage of this file to reach 100%:

1. ensure generated TaskRun's basic information are correct
2. ensure generated TaskRun's input and output resources are correct
3. ensure generated TaskRun's spec special input params are correct

Also did some refine:

1. Change the "source" and "url" in generate_tekton.go to the const
2. git ignore the JetBrains IDE config
3. fix the typo `containing`
4. Remove an additional newline

Please review