### PR TITLE
Change to cluster-scope operator

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
+		Namespace:          "",
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})
 	if err != nil {

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: build-operator
@@ -15,6 +15,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - serviceaccounts
   verbs:
   - create
   - delete
@@ -92,4 +93,3 @@ rules:
   - patch
   - update
   - watch
-

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,11 +1,12 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: build-operator
 subjects:
 - kind: ServiceAccount
   name: build-operator
+  namespace: build-operator
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: build-operator
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- Change the operator to cluster scope follow by the operator user guide:
https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md

- Change to use `ClusterRole` and `ClusterRoleBinding`

- Add `serviceaccounts` permission for ClusterRole, because the controller still need to operate the serviceaccount during the build.

Please review, Thanks!