### PR TITLE
Add missing CRD file reference

### DIFF
--- a/hack/crd.sh
+++ b/hack/crd.sh
@@ -15,6 +15,7 @@ CRDS=(
     deploy/operator.yaml
     deploy/crds/build.dev_buildstrategies_crd.yaml
     deploy/crds/build.dev_builds_crd.yaml
+    deploy/crds/build.dev_clusterbuildstrategies_crd.yaml
     # build strategies
     samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
     samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml


### PR DESCRIPTION
This was breaking my local test of the controllers, when
following the "try it" README.md section.

The controller manager will fail to start if this is not added in
advance, when running `make local`