### PR TITLE
Solve the unstructured.Unstructured error message in controller log

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -185,13 +185,7 @@ func serveCRMetrics(cfg *rest.Config) error {
 	if err != nil {
 		return err
 	}
-	// Get the namespace the operator is currently deployed in.
-	operatorNs, err := k8sutil.GetOperatorNamespace()
-	if err != nil {
-		return err
-	}
-	// To generate metrics in other namespaces, add the values below.
-	ns := []string{operatorNs}
+	ns := []string{""}
 	// Generate and serve custom resource specific metrics.
 	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
 	if err != nil {


### PR DESCRIPTION
After we change to cluster scope operator, there are many error messages like:
```
...
E0315 10:58:13.324893       1 reflector.go:123] github.com/operator-framework/operator-sdk/pkg/kube-metrics/store.go:65: Failed to list *unstructured.Unstructured: the server could not find the requested resource
E0315 10:58:14.331242       1 reflector.go:123] github.com/operator-framework/operator-sdk/pkg/kube-metrics/store.go:65: Failed to list *unstructured.Unstructured: the server could not find the requested resource
E0315 10:58:15.455737       1 reflector.go:123] github.com/operator-framework/operator-sdk/pkg/kube-metrics/store.go:65: Failed to list *unstructured.Unstructured: the server could not find the requested resource
E0315 10:58:16.461906       1 reflector.go:123] github.com/operator-framework/operator-sdk/pkg/kube-metrics/store.go:65: Failed to list *unstructured.Unstructured: the server could not find the requested resource
E0315 10:58:17.469309       1 reflector.go:123] github.com/operator-framework/operator-sdk/pkg/kube-metrics/store.go:65: Failed to list *unstructured.Unstructured: the server could not find the requested resource
E0315 10:58:18.475601       1 reflector.go:123] github.com/operator-framework/operator-sdk/pkg/kube-metrics/store.go:65: Failed to list *unstructured.Unstructured: the server could not find the requested resource
...
```

After I searched in Google, I found it is a known issue:
https://github.com/operator-framework/operator-sdk/issues/1858

After change the namespace to empty in `cmd/manager/main.go` serveCRMetrics() func.

The error message disappears and the log became normal.

Provid this PR to fix this issue.

