### PR TITLE
Refine the operator name in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 # output directory, where all artifacts will be created and managed
 OUTPUT_DIR ?= build/_output
 # relative path to operator binary
-OPERATOR = $(OUTPUT_DIR)/bin/operator
+OPERATOR = $(OUTPUT_DIR)/bin/build-operator
 # golang cache directory path
 GOCACHE ?= $(shell echo ${PWD})/$(OUTPUT_DIR)/gocache
 # golang target architecture


### PR DESCRIPTION
Hi all,

I provided this PR because I need to patch some configurations to build the controller image by using `operator-sdk build`. Please also let me know if there is any other good way.

First of all, the binary name which operator-sdk requires is `build-operator`:
https://github.com/redhat-developer/build/blob/master/Dockerfile#L8

So if I build by using `operator-sdk build` by default directly, it will report error:
```
✘-1 $ operator-sdk build us.icr.io/knative_jordan/build-controller
INFO[0036] Building OCI image us.icr.io/knative_jordan/build-controller 
Sending build context to Docker daemon  131.9MB
Step 1/7 : FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ---> 6ce38bb5210c
Step 2/7 : ENV OPERATOR=/usr/local/bin/build-operator     USER_UID=1001     USER_NAME=build-operator
 ---> Using cache
 ---> 473e8594f489
Step 3/7 : COPY build/_output/bin/build-operator ${OPERATOR}
COPY failed: stat /var/lib/docker/tmp/docker-builder310218286/build/_output/bin/build-operator: no such file or directory
```

It because the repo name is `build` so the generated binary is `build`, not the `build-operator`, so report: `build-operator: no such file or directory`

I can also refine by using this PR to use `make build` to build binary first, then the `operator-sdk build` can use the binary from `make build` directly.

So I also would like to know how you build the controller image?

I think, like other controller or operator, the `repo name` should be the same as `controller name` then the default `operator-sdk` build process can be executed without error:
```
Change:
WORKDIR /go/src/github.com/redhat-developer/build-operator
TO
WORKDIR /go/src/github.com/redhat-developer/build
```

Any suggestion?