### PR TITLE
Refine the Dockerfile in root folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Shoubhik Bose <shbose@redhat.com>"
 ENV LANG=en_US.utf8
 
-COPY --from=builder /go/src/github.com/redhat-developer/build-operator/build/_output/bin/operator /usr/local/bin/build-operator
+COPY --from=builder /go/src/github.com/redhat-developer/build-operator/build/_output/bin/build-operator /usr/local/bin/build-operator
 
 USER 10001
 


### PR DESCRIPTION
Hi all,

I just found there is another `Dockerfile` in the root path, I think it should be used by RedHat internally. (We use `operator-sdk build` command to build by using the build/Dockerfile` directly)

I forgot the rename this binary name and fix in this PR, please review.

BTW, are you still using this Dockerfile? And do we want to maintain two Dockerfiles in this repo? I think it is a little confusing.
