### PR TITLE
Refine the secret name in Build example yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,12 @@ spec:
     kind: ClusterBuildStrategy
   builder:
     image: heroku/buildpacks:18
-    credentials: quayio-olemefer
+    credentials:
+      name: builder-registry-credentials
   output:
     image: quay.io/olemefer/nodejs-ex:v1
     credentials:
-      name: quayio-olemefer
+      name: output-registry-credentials
 ```
 
 ### `BuildRun`


### PR DESCRIPTION
Refine the secret name in Build example yaml as a better name.

- First the `credentials` needs the `name` parameters

-  Change the secret names for builder and output to a better names