### PR TITLE
Add resource limit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ spec:
     image: heroku/buildpacks:18
     credentials:
       name: builder-registry-credentials
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
   output:
     image: quay.io/olemefer/nodejs-ex:v1
     credentials:

--- a/deploy/crds/build.dev_buildruns_crd.yaml
+++ b/deploy/crds/build.dev_buildruns_crd.yaml
@@ -61,6 +61,25 @@ spec:
                   description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                   type: string
               type: object
+            resources:
+              description: 'Compute Resources required by the build container which
+                can overwrite the configuration in Build. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
             serviceAccount:
               description: ServiceAccount refers to the kubernetes serviceaccount
                 which is used for resource control. Default serviceaccount will be

--- a/deploy/crds/build.dev_builds_crd.yaml
+++ b/deploy/crds/build.dev_builds_crd.yaml
@@ -105,6 +105,25 @@ spec:
                 - value
                 type: object
               type: array
+            resources:
+              description: 'Compute Resources required by the build container. More
+                info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
             source:
               description: Source refers to the Git repository containing the source
                 code to be built.

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -38,6 +38,11 @@ type BuildSpec struct {
 	// +optional
 	Parameters *[]Parameter `json:"parameters,omitempty"`
 
+	// Compute Resources required by the build container.
+	// More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+
 	// Output refers to the location where the generated
 	// image would be pushed to.
 	Output Image `json:"output"`

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -16,6 +16,12 @@ type BuildRunSpec struct {
 	// BuildRef refers to the Build
 	BuildRef *BuildRef `json:"buildRef"`
 
+	// Compute Resources required by the build container
+	// which can overwrite the configuration in Build.
+	// More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+
 	// ServiceAccount refers to the kubernetes serviceaccount
 	// which is used for resource control.
 	// Default serviceaccount will be set if it is empty

--- a/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
@@ -155,6 +155,11 @@ func (in *BuildRunSpec) DeepCopyInto(out *BuildRunSpec) {
 		*out = new(BuildRef)
 		**out = **in
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ServiceAccount != nil {
 		in, out := &in.ServiceAccount, &out.ServiceAccount
 		*out = new(string)
@@ -229,6 +234,11 @@ func (in *BuildSpec) DeepCopyInto(out *BuildSpec) {
 			*out = make([]Parameter, len(*in))
 			copy(*out, *in)
 		}
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Output.DeepCopyInto(&out.Output)
 	return

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -149,12 +149,20 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 	if build.Spec.StrategyRef.Kind == nil || *build.Spec.StrategyRef.Kind == buildv1alpha1.NamespacedBuildStrategyKind {
 		buildStrategy := r.retrieveBuildStrategy(build, request)
 		if buildStrategy != nil {
-			generatedTaskRun = generateTaskRun(build, buildRun, serviceAccount.Name, buildStrategy.Spec.BuildSteps)
+			generatedTaskRun, err = generateTaskRun(build, buildRun, serviceAccount.Name, buildStrategy.Spec.BuildSteps)
+			if err != nil {
+				reqLogger.Error(err, "Failed to generate TaskRun", "BuildRun", buildRun.Name)
+				return reconcile.Result{}, err
+			}
 		}
 	} else if *build.Spec.StrategyRef.Kind == buildv1alpha1.ClusterBuildStrategyKind {
 		clusterBuildStrategy := r.retrieveClusterBuildStrategy(build, request)
 		if clusterBuildStrategy != nil {
-			generatedTaskRun = generateTaskRun(build, buildRun, serviceAccount.Name, clusterBuildStrategy.Spec.BuildSteps)
+			generatedTaskRun, err = generateTaskRun(build, buildRun, serviceAccount.Name, clusterBuildStrategy.Spec.BuildSteps)
+			if err != nil {
+				reqLogger.Error(err, "Failed to generate TaskRun", "BuildRun", buildRun.Name)
+				return reconcile.Result{}, err
+			}
 		}
 	} else {
 		log.Error(err, "Unsupported BuildStrategy Kind", "BuildStrategyKind", build.Spec.StrategyRef.Kind)

--- a/samples/build/build_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/build/build_buildpacks-v3_namespaced_cr.yaml
@@ -11,5 +11,12 @@ spec:
     kind: BuildStrategy
   builder:
     image: heroku/buildpacks:18
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+    request:
+      cpu: "500m"
+      memory: "1Gi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/samples/build/build_kaniko_cr.yaml
+++ b/samples/build/build_kaniko_cr.yaml
@@ -11,5 +11,9 @@ spec:
     kind: ClusterBuildStrategy
   dockerfile: Dockerfile
   pathContext: ./
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/samples/buildrun/buildrun_buildah_cr.yaml
+++ b/samples/buildrun/buildrun_buildah_cr.yaml
@@ -6,3 +6,7 @@ metadata:
 spec:
   buildRef:
     name: buildah-golang-build
+  resources:
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"

--- a/samples/buildrun/buildrun_kaniko_cr.yaml
+++ b/samples/buildrun/buildrun_kaniko_cr.yaml
@@ -6,3 +6,6 @@ metadata:
 spec:
   buildRef:
     name: kaniko-golang-build
+  resources:
+    limits:
+      cpu: "1000m"

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 
 var (
 	retryInterval         = time.Second * 5
-	timeout               = time.Second * 60
+	timeout               = time.Second * 120
 	cleanupRetryInterval  = time.Second * 1
 	cleanupTimeout        = time.Second * 5
 	EnvVarImageRepo       = "TEST_IMAGE_REPO"
@@ -58,7 +58,7 @@ func TestBuild(t *testing.T) {
 
 	// run subtests
 	t.Run("build-group", func(t *testing.T) {
-		t.Run("Buildah and Buildpack", BuildCluster)
+		t.Run("Build_e2e_tests", BuildCluster)
 	})
 }
 

--- a/test/e2e/validators.go
+++ b/test/e2e/validators.go
@@ -109,8 +109,8 @@ func validateController(
 
 	// Ensure that eventually the Build moves to Succeeded.
 	foundSuccessful := false
-	for i := 1; i <= 6; i++ {
-		time.Sleep(20 * time.Second)
+	for i := 1; i <= 30; i++ {
+		time.Sleep(10 * time.Second)
 		err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: testBuildRun.Name, Namespace: namespace}, testBuildRun)
 		require.NoError(t, err)
 


### PR DESCRIPTION
Add resource limit support for this feature: https://github.com/redhat-developer/build/issues/91

- Add resource parameter for both Build and BuildRun. If the resource is defined in both Build and BuildRun, the BuildRun values will overwrite the values in Build
- Change the generateTaskRun method to merge and add resource limit into the `step.Resources`

- Add two more unit tests for generateTaskRun
- Add the resource limit to some of the e2e test Build or BuildRun CRs.

Please review. Thanks!