### PR TITLE
Consolidate context directory for Kaniko and BuildAh

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ metadata:
 spec:
   source:
     url: https://github.com/sbose78/taxi
+    contextDir: .
   strategy:
     name: kaniko
     kind: ClusterBuildStrategy
   dockerfile: Dockerfile
-  pathContext: ./
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app
 ```

--- a/pkg/controller/buildrun/generate_taskrun.go
+++ b/pkg/controller/buildrun/generate_taskrun.go
@@ -3,14 +3,15 @@ package buildrun
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+
 	buildv1alpha1 "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	taskv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -31,10 +32,10 @@ const (
 func getStringTransformations(fullText string) string {
 
 	stringTransformations := map[string]string{
-		"$(build.output.image)":  "$(outputs.resources.image.url)",
-		"$(build.builder.image)": fmt.Sprintf("$(inputs.params.%s)", inputParamBuilderImage),
-		"$(build.dockerfile)":    fmt.Sprintf("$(inputs.params.%s)", inputParamDockerfile),
-		"$(build.pathContext)":   fmt.Sprintf("$(inputs.params.%s)", inputParamPathContext),
+		"$(build.output.image)":      "$(outputs.resources.image.url)",
+		"$(build.builder.image)":     fmt.Sprintf("$(inputs.params.%s)", inputParamBuilderImage),
+		"$(build.dockerfile)":        fmt.Sprintf("$(inputs.params.%s)", inputParamDockerfile),
+		"$(build.source.contextDir)": fmt.Sprintf("$(inputs.params.%s)", inputParamPathContext),
 	}
 
 	// Run the text through all possible replacements
@@ -180,17 +181,17 @@ func generateTaskRun(build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRu
 	expectedTaskRun := &taskv1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: buildRun.Name + "-",
-			Namespace: buildRun.Namespace,
+			Namespace:    buildRun.Namespace,
 			Labels: map[string]string{
-				buildv1alpha1.LabelBuild: build.Name,
-				buildv1alpha1.LabelBuildGeneration: strconv.FormatInt(build.Generation, 10),
-				buildv1alpha1.LabelBuildRun: buildRun.Name,
+				buildv1alpha1.LabelBuild:              build.Name,
+				buildv1alpha1.LabelBuildGeneration:    strconv.FormatInt(build.Generation, 10),
+				buildv1alpha1.LabelBuildRun:           buildRun.Name,
 				buildv1alpha1.LabelBuildRunGeneration: strconv.FormatInt(buildRun.Generation, 10),
 			},
 		},
 		Spec: taskv1.TaskRunSpec{
 			ServiceAccountName: serviceAccountName,
-			TaskSpec: taskSpec,
+			TaskSpec:           taskSpec,
 			Inputs: taskv1.TaskRunInputs{
 				Resources: []taskv1.TaskResourceBinding{
 					{

--- a/pkg/controller/buildrun/generate_taskrun_test.go
+++ b/pkg/controller/buildrun/generate_taskrun_test.go
@@ -2,10 +2,11 @@ package buildrun
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"reflect"
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	buildv1alpha1 "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -15,9 +16,9 @@ import (
 )
 
 const (
-	buildah = "buildah"
+	buildah    = "buildah"
 	buildpacks = "buildpacks-v3"
-	url     = "https://github.com/sbose78/taxi"
+	url        = "https://github.com/sbose78/taxi"
 )
 
 func TestGenerateTaskSpec(t *testing.T) {
@@ -30,9 +31,9 @@ func TestGenerateTaskSpec(t *testing.T) {
 	truePtr := true
 
 	type args struct {
-		build            *buildv1alpha1.Build
-		buildRun         *buildv1alpha1.BuildRun
-		buildStrategy    *buildv1alpha1.BuildStrategy
+		build         *buildv1alpha1.Build
+		buildRun      *buildv1alpha1.BuildRun
+		buildStrategy *buildv1alpha1.BuildStrategy
 	}
 	tests := []struct {
 		name string
@@ -72,7 +73,7 @@ func TestGenerateTaskSpec(t *testing.T) {
 					},
 					Spec: buildv1alpha1.BuildRunSpec{
 						BuildRef: &buildv1alpha1.BuildRef{
-							Name:       buildah,
+							Name: buildah,
 						},
 					},
 				},
@@ -86,10 +87,10 @@ func TestGenerateTaskSpec(t *testing.T) {
 									Image:      "$(build.builder.image)",
 									WorkingDir: "/workspace/source",
 									Command: []string{
-										"buildah", "bud", "--tls-verify=false", "--layers", "-f", "$(build.dockerfile)", "-t", "$(build.output.image)", "$(build.pathContext)",
+										"buildah", "bud", "--tls-verify=false", "--layers", "-f", "$(build.dockerfile)", "-t", "$(build.output.image)", "$(build.source.contextDir)",
 									},
 									Args: []string{
-										"buildah", "bud", "--tls-verify=false", "--layers", "-f", "$(build.dockerfile)", "-t", "$(build.output.image)", "$(build.pathContext)",
+										"buildah", "bud", "--tls-verify=false", "--layers", "-f", "$(build.dockerfile)", "-t", "$(build.output.image)", "$(build.source.contextDir)",
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -175,9 +176,9 @@ func TestGenerateTaskRun(t *testing.T) {
 	serviceAccountName := buildpacks + "-serviceaccount"
 
 	type args struct {
-		build            *buildv1alpha1.Build
-		buildRun         *buildv1alpha1.BuildRun
-		buildStrategy    *buildv1alpha1.BuildStrategy
+		build         *buildv1alpha1.Build
+		buildRun      *buildv1alpha1.BuildRun
+		buildStrategy *buildv1alpha1.BuildStrategy
 	}
 	tests := []struct {
 		name string
@@ -189,7 +190,7 @@ func TestGenerateTaskRun(t *testing.T) {
 			args{
 				build: &buildv1alpha1.Build{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: buildah,
+						Name:      buildah,
 						Namespace: namespace,
 					},
 					Spec: buildv1alpha1.BuildSpec{
@@ -206,12 +207,12 @@ func TestGenerateTaskRun(t *testing.T) {
 				},
 				buildRun: &buildv1alpha1.BuildRun{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: buildah + "-run",
+						Name:      buildah + "-run",
 						Namespace: namespace,
 					},
 					Spec: buildv1alpha1.BuildRunSpec{
 						BuildRef: &buildv1alpha1.BuildRef{
-							Name:       buildah,
+							Name: buildah,
 						},
 						Resources: &corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
@@ -257,13 +258,13 @@ func TestGenerateTaskRun(t *testing.T) {
 			args{
 				build: &buildv1alpha1.Build{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: buildpacks,
+						Name:      buildpacks,
 						Namespace: namespace,
 					},
 					Spec: buildv1alpha1.BuildSpec{
 						Source: buildv1alpha1.GitSource{
-							URL: url,
-							Revision: &revision,
+							URL:        url,
+							Revision:   &revision,
 							ContextDir: &contextDir,
 						},
 						StrategyRef: &buildv1alpha1.StrategyRef{
@@ -285,12 +286,12 @@ func TestGenerateTaskRun(t *testing.T) {
 				},
 				buildRun: &buildv1alpha1.BuildRun{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: buildpacks + "-run",
+						Name:      buildpacks + "-run",
 						Namespace: namespace,
 					},
 					Spec: buildv1alpha1.BuildRunSpec{
 						BuildRef: &buildv1alpha1.BuildRef{
-							Name:       buildpacks,
+							Name: buildpacks,
 						},
 						Resources: &corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
@@ -336,9 +337,9 @@ func TestGenerateTaskRun(t *testing.T) {
 			got, err := generateTaskRun(tt.args.build, tt.args.buildRun, serviceAccountName, tt.args.buildStrategy.Spec.BuildSteps)
 			assert.True(t, reflect.DeepEqual(err, nil))
 			// ensure generated TaskRun's basic information are correct
-			assert.True(t, reflect.DeepEqual(true, strings.Contains(got.GenerateName, tt.args.buildRun.Name + "-")))
+			assert.True(t, reflect.DeepEqual(true, strings.Contains(got.GenerateName, tt.args.buildRun.Name+"-")))
 			assert.True(t, reflect.DeepEqual(got.Namespace, namespace))
-			assert.True(t, reflect.DeepEqual(got.Spec.ServiceAccountName, buildpacks + "-serviceaccount"))
+			assert.True(t, reflect.DeepEqual(got.Spec.ServiceAccountName, buildpacks+"-serviceaccount"))
 			assert.True(t, reflect.DeepEqual(got.Labels[buildv1alpha1.LabelBuild], tt.args.build.Name))
 			assert.True(t, reflect.DeepEqual(got.Labels[buildv1alpha1.LabelBuildRun], tt.args.buildRun.Name))
 

--- a/samples/build/build_kaniko_cr.yaml
+++ b/samples/build/build_kaniko_cr.yaml
@@ -10,7 +10,6 @@ spec:
     name: kaniko
     kind: ClusterBuildStrategy
   dockerfile: Dockerfile
-  pathContext: ./
   resources:
     limits:
       cpu: "500m"

--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -16,7 +16,7 @@ spec:
         - bud
         - --tag=$(build.output.image)
         - --file=$(build.dockerfile)
-        - $(build.pathContext)
+        - $(build.source.contextDir)
       volumeMounts:
         - name: buildah-images
           mountPath: /var/lib/containers/storage

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -20,5 +20,5 @@ spec:
       args:
         - --skip-tls-verify=true
         - --dockerfile=$(build.dockerfile)
-        - --context=/workspace/source/$(build.pathContext)
+        - --context=/workspace/source/$(build.source.contextDir)
         - --destination=$(build.output.image)

--- a/test/data/build_buildah_cr_custom_context+dockerfile.yaml
+++ b/test/data/build_buildah_cr_custom_context+dockerfile.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: Build
+metadata:
+  name: buildah-custom-context-dockerfile
+spec:
+  source:
+    url: https://github.com/SaschaSchwarze0/npm-simple
+    contextDir: renamed
+  strategy:
+    name: buildah
+    kind: ClusterBuildStrategy
+  dockerfile: RenamedDockerfile
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/renamed-dockerfile

--- a/test/data/build_kaniko_cr_custom_context+dockerfile.yaml
+++ b/test/data/build_kaniko_cr_custom_context+dockerfile.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: Build
+metadata:
+  name: kaniko-custom-context-dockerfile
+spec:
+  source:
+    url: https://github.com/SaschaSchwarze0/npm-simple
+    contextDir: renamed
+  strategy:
+    name: kaniko
+    kind: ClusterBuildStrategy
+  dockerfile: RenamedDockerfile
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/renamed-dockerfile

--- a/test/data/build_kaniko_cr_private_github.yaml
+++ b/test/data/build_kaniko_cr_private_github.yaml
@@ -10,6 +10,5 @@ spec:
     name: kaniko
     kind: ClusterBuildStrategy
   dockerfile: Dockerfile
-  pathContext: ./
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/data/build_kaniko_cr_private_gitlab.yaml
+++ b/test/data/build_kaniko_cr_private_gitlab.yaml
@@ -10,6 +10,5 @@ spec:
     name: kaniko
     kind: ClusterBuildStrategy
   dockerfile: Dockerfile
-  pathContext: ./
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml
+++ b/test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: BuildRun
+metadata:
+  name: buildah-custom-context-dockerfile
+spec:
+  buildRef:
+    name: buildah-custom-context-dockerfile

--- a/test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml
+++ b/test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: BuildRun
+metadata:
+  name: kaniko-custom-context-dockerfile
+spec:
+  buildRef:
+    name: kaniko-custom-context-dockerfile

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -94,6 +94,21 @@ func BuildCluster(t *testing.T) {
 	validateController(t, ctx, f, oE.build, oE.buildRun)
 	deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
 
+	// Run e2e tests for kaniko with custom context directory and Dockerfile name
+	oE = newOperatorEmulation(namespace,
+		"kaniko-custom-context-dockerfile",
+		"samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
+		"test/data/build_kaniko_cr_custom_context+dockerfile.yaml",
+		"test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml",
+	)
+	err = BuildTestData(oE)
+	require.NoError(t, err)
+	validateOutputEnvVars(oE.build)
+
+	createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
+	validateController(t, ctx, f, oE.build, oE.buildRun)
+	deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
+
 	// Run e2e tests for source2image
 	oE = newOperatorEmulation(namespace,
 		"example-build-s2i",
@@ -115,6 +130,21 @@ func BuildCluster(t *testing.T) {
 		"samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
 		"samples/build/build_buildah_cr.yaml",
 		"samples/buildrun/buildrun_buildah_cr.yaml",
+	)
+	err = BuildTestData(oE)
+	require.NoError(t, err)
+	validateOutputEnvVars(oE.build)
+
+	createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
+	validateController(t, ctx, f, oE.build, oE.buildRun)
+	deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
+
+	// Run e2e tests for buildah with custom context directory and Dockerfile name
+	oE = newOperatorEmulation(namespace,
+		"buildah-custom-context-dockerfile",
+		"samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
+		"test/data/build_buildah_cr_custom_context+dockerfile.yaml",
+		"test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml",
 	)
 	err = BuildTestData(oE)
 	require.NoError(t, err)


### PR DESCRIPTION
Changes for issue #98.

- I am removing pathContext from the README and the samples and replace it by source.contextDir which was already read in the code
- I am also updating the build strategy to read from build.source.contextDir for consistency and adopted the generate_taskrun accordingly