### PR TITLE
WIP Add kubectl explain

### DIFF
--- a/deploy/crds/build.dev_buildruns_crd.yaml
+++ b/deploy/crds/build.dev_buildruns_crd.yaml
@@ -32,6 +32,7 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       description: BuildRun is the Schema for the buildruns API

--- a/deploy/crds/build.dev_builds_crd.yaml
+++ b/deploy/crds/build.dev_builds_crd.yaml
@@ -29,6 +29,7 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       description: Build is the Schema for the builds API


### PR DESCRIPTION
This PR enables the `kubectl explain` of `build` and `buildrun` resources, by adding the `preserveUnknownFields` property in CRD spec respectively.

The standard output would be as following : (e.g. `buildrun`)
```
KIND:     BuildRun
VERSION:  build.dev/v1alpha1
DESCRIPTION:
     BuildRun is the Schema for the buildruns API
FIELDS:
   apiVersion   <string>
     APIVersion defines the versioned schema of this representation of an
     object. Servers should convert recognized schemas to the latest internal
     value, and may reject unrecognized values. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
   kind <string>
     Kind is a string value representing the REST resource this object
     represents. Servers may infer this from the endpoint the client submits
     requests to. Cannot be updated. In CamelCase. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   metadata     <Object>
     Standard object's metadata. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   spec <Object>
     BuildRunSpec defines the desired state of BuildRun
   status       <Object>
     BuildRunStatus defines the observed state of BuildRun
```