### PR TITLE
Add dependency on SETGID and SETUID for Kaniko

### DIFF
--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -11,7 +11,12 @@ spec:
       securityContext:
         runAsUser: 0
         capabilities:
-          add: ["CHOWN", "DAC_OVERRIDE", "FOWNER"]
+          add:
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+            - SETGID
+            - SETUID
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker

--- a/test/data/build_kaniko_cr_advanced_dockerfile.yaml
+++ b/test/data/build_kaniko_cr_advanced_dockerfile.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: Build
+metadata:
+  name: kaniko-advanced-dockerfile
+spec:
+  source:
+    url: https://github.com/SaschaSchwarze0/java-simple
+  strategy:
+    name: kaniko
+    kind: ClusterBuildStrategy
+  dockerfile: Dockerfile
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/advanced-dockerfile

--- a/test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml
+++ b/test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: BuildRun
+metadata:
+  name: kaniko-advanced-dockerfile
+spec:
+  buildRef:
+    name: kaniko-advanced-dockerfile

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -109,6 +109,21 @@ func BuildCluster(t *testing.T) {
 	validateController(t, ctx, f, oE.build, oE.buildRun)
 	deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
 
+	// Run e2e tests for kaniko with advanced Dockerfile operations
+	oE = newOperatorEmulation(namespace,
+		"kaniko-advanced-dockerfile",
+		"samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
+		"test/data/build_kaniko_cr_advanced_dockerfile.yaml",
+		"test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml",
+	)
+	err = BuildTestData(oE)
+	require.NoError(t, err)
+	validateOutputEnvVars(oE.build)
+
+	createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
+	validateController(t, ctx, f, oE.build, oE.buildRun)
+	deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
+
 	// Run e2e tests for source2image
 	oE = newOperatorEmulation(namespace,
 		"example-build-s2i",


### PR DESCRIPTION
We are currently testing how well builds work with restrictions through a pod security policy for the Tekton pods. The added test case is the result. The test case succeeds against a "normal" k8s cluster. It fails with a psp in place and we are checking which permissions it needs or if certain Dockerfile constructs (`RUN something` after `USER root`) can only work with privileged containers.