### PR TITLE
Add missing Reason column to the Build controller 

### DIFF
--- a/deploy/crds/build.dev_builds_crd.yaml
+++ b/deploy/crds/build.dev_builds_crd.yaml
@@ -8,6 +8,10 @@ spec:
     description: The register status of the Build
     name: Registered
     type: string
+  - JSONPath: .status.reason
+    description: The reason of the registered Build, either an error or succeed message
+    name: Reason
+    type: string
   - JSONPath: .spec.strategy.kind
     description: The BuildStrategy type which is used for this Build
     name: BuildStrategyKind
@@ -196,6 +200,9 @@ spec:
           properties:
             registered:
               description: The Register status of the Build
+              type: string
+            reason:
+              description: The reason of the registered Build, either an error or succeed message
               type: string
           type: object
       type: object

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -64,6 +64,9 @@ type Image struct {
 type BuildStatus struct {
 	// The Registered status of the TaskRun
 	Registered corev1.ConditionStatus `json:"registered,omitempty"`
+
+	// The reason of the registered Build, either an error or succeed message
+	Reason string `json:"reason,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/build/build_controller_test.go
+++ b/pkg/controller/build/build_controller_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse)
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("secret %s does not exist", registrySecret))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
@@ -110,7 +110,7 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionTrue)
+				statusCall := ctl.StubFunc(corev1.ConditionTrue, "Succeeded")
 				statusWriter.UpdateCalls(statusCall)
 
 				result, err := reconciler.Reconcile(request)
@@ -136,7 +136,7 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse)
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("clusterBuildStrategy %s does not exist", buildStrategyName))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
@@ -160,7 +160,7 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionTrue)
+				statusCall := ctl.StubFunc(corev1.ConditionTrue, "Succeeded")
 				statusWriter.UpdateCalls(statusCall)
 
 				result, err := reconciler.Reconcile(request)
@@ -193,7 +193,7 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse)
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("BuildStrategy %s does not exist in namespace %s", buildStrategyName, namespace))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
@@ -217,7 +217,7 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionTrue)
+				statusCall := ctl.StubFunc(corev1.ConditionTrue, "Succeeded")
 				statusWriter.UpdateCalls(statusCall)
 
 				result, err := reconciler.Reconcile(request)

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -144,11 +144,12 @@ func (c *Catalog) SecretList(name string) corev1.SecretList {
 // StubFunc is used to simulate the status of the Build
 // after a .Status().Update() call in the controller. This
 // receives a parameter to return an specific status state
-func (c *Catalog) StubFunc(status corev1.ConditionStatus) func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
+func (c *Catalog) StubFunc(status corev1.ConditionStatus, reason string) func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
 	return func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
 		switch object := object.(type) {
 		case *build.Build:
 			Expect(object.Status.Registered).To(Equal(status))
+			Expect(object.Status.Reason).To(ContainSubstring(reason))
 		}
 		return nil
 	}


### PR DESCRIPTION
From [issue 111](https://github.com/redhat-developer/build/issues/111)
Add missing Reason column for the Build CRD. This have two types of
reasons, either a "Succeed" message, or an error(from resources validations).

This also includes the related unit-tests

Examples:

```sh
$ k -n build-examples get Build
NAME                     REGISTERED   REASON                                              BUILDSTRATEGYKIND      BUILDSTRATEGYNAME   CREATIONTIME
buildpack-nodejs-build   False        secret output-registry-credentials does not exist   ClusterBuildStrategy   buildpacks-v3       8s


$ k -n build-examples get Build
NAME                     REGISTERED   REASON                                   BUILDSTRATEGYKIND       BUILDSTRATEGYNAME   CREATIONTIME
buildpack-nodejs-build   False        unknown strategy ClusterBuildStrategys   ClusterBuildStrategys   buildpacks-v3       3s


```