### PR TITLE
[WIP] External Container Registry for E2E

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ go:
 services:
   - docker
 install:
-  - go get -u github.com/onsi/ginkgo/ginkgo
-  - go get -u github.com/onsi/gomega/...
   - make travis
 script:
   - make

--- a/HACK.md
+++ b/HACK.md
@@ -37,7 +37,6 @@ In the near future, the above would be setup by the operator.
 make clean && make build
 ```
 
-
 * This project uses Golang 1.13+ and operator-sdk 1.15.1.
 * The controllers create/watch Tekton objects.
 
@@ -71,7 +70,7 @@ When building unit-tests, try to follow:
 make test
 ```
 
-### End-to-end tests
+### End-to-End Tests
 
 The following is a list of environment variables you can use when running e2e tests, this will override specific paths under the **Build** CRD [examples](samples/build).
 
@@ -80,13 +79,29 @@ The following is a list of environment variables you can use when running e2e te
 | `TEST_IMAGE_REPO`        | `spec.output.image`            | Image repository for end-to-end tests |
 | `TEST_IMAGE_REPO_SECRET` | `spec.output.credentials.name` | Container credentials, JSON payload   |
 
-The contents of `TEST_IMAGE_REPO_SECRET` contents can be obtained from quay.io using a [robot account](https://docs.quay.io/glossary/robot-accounts.html).
+The contents of `TEST_IMAGE_REPO_SECRET` contents can be obtained from quay.io using a [robot account](https://docs.quay.io/glossary/robot-accounts.html). The contents of this file are like the following example:
+
+```json
+{
+  "auths": {
+    "quay.io": {
+      "auth": "<secret-credentials>",
+      "email": ""
+    }
+  }
+}
+```
 
 To execute the end-to-end tests, run:
 
 ```sh
 make test-e2e TEST_IMAGE_REPO_SECRET="<secret>"
 ```
+
+### Private Git Repositories
+
+End-to-end tests can also be executed with the context of private Git repositories, using the
+following environment variables to configure it.
 
 | Environment Variable  | Path                           | Description                           |
 |-----------------------|--------------------------------|---------------------------------------|

--- a/HACK.md
+++ b/HACK.md
@@ -70,7 +70,7 @@ When building unit-tests, try to follow:
 make test
 ```
 
-### End-to-End Tests
+## End-to-End Tests
 
 The following is a list of environment variables you can use when running e2e tests, this will override specific paths under the **Build** CRD [examples](samples/build).
 
@@ -97,6 +97,8 @@ To execute the end-to-end tests, run:
 ```sh
 make test-e2e TEST_IMAGE_REPO_SECRET="<secret>"
 ```
+
+Currently the end-to-end tests are not run in parallel, and may take a few minutes to complete. In average you may expect up to 10 minutes to complete all test cases.
 
 ### Private Git Repositories
 

--- a/HACK.md
+++ b/HACK.md
@@ -71,53 +71,47 @@ When building unit-tests, try to follow:
 make test
 ```
 
-## End-to-end tests
+### End-to-end tests
 
 The following is a list of environment variables you can use when running e2e tests, this will override specific paths under the **Build** CRD [examples](samples/build).
 
-Env var | Path | Definition
---- | --- | --- |
-**TEST_IMAGE_REPO** | **spec.output.image** | Registry endpoint to push images |
-**TEST_IMAGE_REPO_SECRET** | **spec.output.credentials.name** | Registry endpoint secret(_usually of the type kubernetes.io/dockerconfigjson_) |
+| Environment Variable     | Path                           | Description                           |
+|--------------------------|--------------------------------|---------------------------------------|
+| `TEST_IMAGE_REPO`        | `spec.output.image`            | Image repository for end-to-end tests |
+| `TEST_IMAGE_REPO_SECRET` | `spec.output.credentials.name` | Container credentials, JSON payload   |
 
-For running E2E tests for private repositories, the **TEST_WITH_PRIVATE_REPO** environment variable needs to be set to **true**.
-If the Build private repositories [examples](test/data) contain references to private repositories you don´t have access, use
-the following variables for any related modification in the examples.
+The contents of `TEST_IMAGE_REPO_SECRET` contents can be obtained from quay.io using a [robot account](https://docs.quay.io/glossary/robot-accounts.html).
 
-Env var | Path | Definition
---- | --- | --- |
-**TEST_PRIVATE_REPO** | _none_ | Enables running e2e tests for private repositories |
-**TEST_PRIVATE_GITHUB** | **spec.source.url** | Private URL for the samples of the form *git@github.com* |
-**TEST_PRIVATE_GITLAB** | **spec.source.url** | Private URL for the samples of the form *git@gitlab.com* |
-**TEST_SOURCE_SECRET** | **spec.source.credentials.name** | A secret containing the SSH private key for accessing the above private repository. See [ssh-authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#ssh-authentication-git). The secret definition must define two annotations: `tekton.dev/git-0: github.com` and `tekton.dev/git-1: gitlab.com`  |
-
-To run all strategies except buildpacks-v3 and none private git repositories tests, execute:
+To execute the end-to-end tests, run:
 
 ```sh
-operator-sdk test local ./test/e2e --up-local --namespace build-examples
+make test-e2e TEST_IMAGE_REPO_SECRET="<secret>"
 ```
 
-To run all strategies including buildpacks-v3 and none private git repositories tests, [setup your Quay credentials](samples/buildstrategy/buildpacks-v3#try-it-) and execute:
+| Environment Variable  | Path                           | Description                           |
+|-----------------------|--------------------------------|---------------------------------------|
+| `TEST_PRIVATE_REPO`   | _none_                         | Enable private repository e2e tests   |
+| `TEST_PRIVATE_GITHUB` | `spec.source.url`              | Private URL, like `git@github.com`    |
+| `TEST_PRIVATE_GITLAB` | `spec.source.url`              | Private URL, like `git@gitlab.com`    |
+| `TEST_SOURCE_SECRET`  | `spec.source.credentials.name` | Private repository credentials        |
+
+On using `TEST_SOURCE_SECRET`, the environment variable must contain the name of the Kubernetes Secret containing SSH private key, for given private Git repository. See [ssh-authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#ssh-authentication-git). The secret definition must define the following annotations:
+- `tekton.dev/git-0: github.com`
+- `tekton.dev/git-1: gitlab.com`
+
+To run end-to-end tests which also includes private Git repositories, run:
 
 ```sh
-TEST_IMAGE_REPO=quay.io/shbose/nodejs-ex:latest TEST_IMAGE_REPO_SECRET=regcred  operator-sdk test local ./test/e2e --up-local --namespace build-examples
+make test-e2e \
+  TEST_PRIVATE_REPO="true" \
+  TEST_PRIVATE_GITHUB="git@github.com:<youruser>/<your-repo>.git" \
+  TEST_PRIVATE_GITLAB="git@gitlab.com:<youruser>/<your-repo>.git" \
+  TEST_SOURCE_SECRET="<secret-name>"
 ```
 
-To run all strategies and also the private git repositories tests except buildpacks-v3, execute:
+For private Git repositories tests, a secret of the type `kubernetes.io/ssh-auth` is required, here is an example:
 
-```sh
-export TEST_PRIVATE_REPO=true
-export TEST_PRIVATE_GITHUB=git@github.com:<youruser>/<your-repo>.git
-export TEST_PRIVATE_GITLAB=git@gitlab.com:<youruser>/<your-repo>.git
-export TEST_SOURCE_SECRET=<your-github-ssh-all>
-operator-sdk test local ./test/e2e --up-local --namespace build-examples --go-test-flags "-timeout=20m"
-```
-
-_Note:_ The e2e tests timeout defaults to 10min, when running with the private git repositories tests, more than 15 minutes is recommended.
-
-For private git repositories test a secret of the type `kubernetes.io/ssh-auth` is required, here is an example of such a secret:
-
-```yaml
+```yml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,40 @@ SHELL := /bin/bash
 OUTPUT_DIR ?= build/_output
 # relative path to operator binary
 OPERATOR = $(OUTPUT_DIR)/bin/build-operator
+
 # golang cache directory path
 GOCACHE ?= $(shell echo ${PWD})/$(OUTPUT_DIR)/gocache
 # golang target architecture
 GOARCH ?= amd64
 # golang global flags
 GO_FLAGS ?= -v -mod=vendor
+
 # configure zap based logr
-ZAP_ENCODER_FLAG = --zap-level=debug --zap-encoder=console
+OPERATOR_FLAGS ?= --zap-level=1 --zap-level=debug --zap-encoder=console
+# extra flags passed to operator-sdk
+OPERATOR_SDK_EXTRA_ARGS ?= --debug
+
+# test namespace name
+TEST_NAMESPACE ?= default
+
 # CI: tekton pipelines operator version
 TEKTON_VERSION ?= v0.10.1
 # CI: operator-sdk version
 SDK_VERSION ?= v0.15.2
+
+# test repository to store images build during end-to-end tests
+TEST_IMAGE_REPO ?= quay.io/redhat-developer/build-e2e
+# test repository secret, must be defined during runtime
+TEST_IMAGE_REPO_SECRET ?=
+
+# enable private git repository tests
+TEST_PRIVATE_REPO ?= false
+# github private repository url
+TEST_PRIVATE_GITHUB ?=
+# gitlab private repository url
+TEST_PRIVATE_GITLAB ?=
+# private repository authentication secret
+TEST_SOURCE_SECRET ?=
 
 .EXPORT_ALL_VARIABLES:
 
@@ -31,25 +53,42 @@ build: $(OPERATOR)
 $(OPERATOR): vendor
 	go build $(GO_FLAGS) -o $(OPERATOR) cmd/manager/main.go
 
-.PHONY: test
-test:
-	GO111MODULE=on ginkgo \
-	  -randomizeAllSpecs \
-	  -randomizeSuites \
-	  -failOnPending \
-	  -nodes=4 \
-	  -compilers=2 \
-	  -slowSpecThreshold=240 \
-	  -race \
-	  -cover \
-	  -trace \
-	  internal/... \
-	  pkg/...
+install-ginkgo:
+	go get -u github.com/onsi/ginkgo/ginkgo
+	go get -u github.com/onsi/gomega/...
 
-local:
+test: test-unit test-e2e
+
+.PHONY: test-unit
+test-unit:
+	GO111MODULE=on ginkgo \
+		-randomizeAllSpecs \
+		-randomizeSuites \
+		-failOnPending \
+		-nodes=4 \
+		-compilers=2 \
+		-slowSpecThreshold=240 \
+		-race \
+		-cover \
+		-trace \
+		internal/... \
+		pkg/...
+
+.PHONY: test-e2e
+test-e2e:
+	operator-sdk --verbose test local ./test/e2e \
+		--up-local \
+		--namespace="$(TEST_NAMESPACE)" \
+		--go-test-flags="$(GO_TEST_FLAGS)" \
+		--local-operator-flags="$(OPERATOR_FLAGS)" \
+			$(OPERATOR_SDK_EXTRA_ARGS)
+
+crds:
 	-hack/crd.sh uninstall
 	@hack/crd.sh install
-	operator-sdk run --local --operator-flags="$(ZAP_ENCODER_FLAG)"
+
+local: crds build
+	operator-sdk run --local --operator-flags="$(ZAP_ENCODER_FLAG)" $(OPERATOR_SDK_EXTRA_ARGS)
 
 clean:
 	rm -rf $(OUTPUT_DIR)
@@ -57,7 +96,7 @@ clean:
 gen-fakes:
 	./hack/generate-fakes.sh
 
-travis:
+travis: install-ginkgo
 	./hack/install-operator-sdk.sh
 	./hack/install-kind.sh
 	./hack/install-tekton.sh

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ GOCACHE ?= $(shell echo ${PWD})/$(OUTPUT_DIR)/gocache
 GOARCH ?= amd64
 # golang global flags
 GO_FLAGS ?= -v -mod=vendor
+# golang test floags
+GO_TEST_FLAGS ?= -failfast -timeout=15m
 
 # configure zap based logr
 OPERATOR_FLAGS ?= --zap-level=1 --zap-level=debug --zap-encoder=console

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test-unit:
 		pkg/...
 
 .PHONY: test-e2e
-test-e2e:
+test-e2e: crds
 	operator-sdk --verbose test local ./test/e2e \
 		--up-local \
 		--namespace="$(TEST_NAMESPACE)" \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOARCH ?= amd64
 # golang global flags
 GO_FLAGS ?= -v -mod=vendor
 # golang test floags
-GO_TEST_FLAGS ?= -failfast -timeout=15m
+GO_TEST_FLAGS ?= -failfast -timeout=20m
 
 # configure zap based logr
 OPERATOR_FLAGS ?= --zap-level=1 --zap-level=debug --zap-encoder=console

--- a/hack/install-operator-sdk.sh
+++ b/hack/install-operator-sdk.sh
@@ -38,10 +38,10 @@ gpg --keyserver="${KEY_SERVER}" --recv-key "${KEY_ID}"
 #
 
 echo "# Downloading operator-sdk bindary (${SDK_URL})"
-wget --output-document="${SDK_BIN}" "${SDK_URL}"
+wget --quiet --output-document="${SDK_BIN}" "${SDK_URL}"
 
 echo "# Downloading operator-sdk signature (${SDK_URL})"
-wget --output-document="${SDK_BIN}.asc" "${SDK_URL}.asc"
+wget --quiet --output-document="${SDK_BIN}.asc" "${SDK_URL}.asc"
 
 echo "# Validating download signature..."
 gpg --verify "${SDK_BIN}.asc" "${SDK_BIN}"

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -18,293 +17,53 @@ func TestMain(m *testing.M) {
 }
 
 var (
-	retryInterval            = time.Second * 5
-	timeout                  = time.Second * 120
-	cleanupRetryInterval     = time.Second * 1
-	cleanupTimeout           = time.Second * 5
-	EnvVarEnablePrivateRepos = "TEST_PRIVATE_REPO"
+	retryInterval        = time.Second * 5
+	timeout              = time.Second * 120
+	cleanupRetryInterval = time.Second * 1
+	cleanupTimeout       = time.Second * 5
 )
 
 func TestBuild(t *testing.T) {
-	buildList := &operator.BuildList{}
-	err := framework.AddToFrameworkScheme(apis.AddToScheme, buildList)
-	if err != nil {
-		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
-	}
+	err := framework.AddToFrameworkScheme(apis.AddToScheme, &operator.BuildList{})
+	require.NoError(t, err, "unable to add BuildList to scheme")
 
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &operator.BuildStrategyList{})
-	if err != nil {
-		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
-	}
+	require.NoError(t, err, "unable to add BuildStrategyList to scheme")
 
 	err = framework.AddToFrameworkScheme(apis.AddToScheme, &operator.ClusterBuildStrategyList{})
-	if err != nil {
-		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
-	}
+	require.NoError(t, err, "unable to add ClusterBuildStrategyList to scheme")
 
 	err = framework.AddToFrameworkScheme(pipelinev1.AddToScheme, &pipelinev1.TaskList{})
-	if err != nil {
-		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
-	}
+	require.NoError(t, err, "unable to add TaskList to scheme")
 
 	err = framework.AddToFrameworkScheme(pipelinev1.AddToScheme, &pipelinev1.TaskRunList{})
-	if err != nil {
-		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
-	}
+	require.NoError(t, err, "unable to add TaskRunList to scheme")
 
-	// run subtests
-	t.Run("build-group", func(t *testing.T) {
-		t.Run("Build_e2e_tests", BuildCluster)
-	})
+	prepareClusterAndTest(t)
 }
 
-func BuildCluster(t *testing.T) {
-	t.Parallel()
+func prepareClusterAndTest(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
-		t.Fatalf("failed to initialize cluster resources: %v", err)
-	}
-	t.Log("Initialized cluster resources")
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// get global framework variables
+
+	t.Log("Initializing cluster resources...")
+	err := ctx.InitializeClusterResources(cleanupOptions(ctx))
+	require.NoError(t, err, "unable to initialize cluster resources")
+
+	ns, err := ctx.GetNamespace()
+	require.NoError(t, err, "unable to obtain namespace")
+
 	f := framework.Global
-	// wait for build-operator to be ready
-	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "build-operator", 1, retryInterval, timeout)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Run e2e tests for kaniko
-	oE := newOperatorEmulation(namespace,
-		"example-build-kaniko",
-		"samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
-		"samples/build/build_kaniko_cr.yaml",
-		"samples/buildrun/buildrun_kaniko_cr.yaml",
+	err = e2eutil.WaitForOperatorDeployment(
+		t,
+		f.KubeClient,
+		ns,
+		"build-operator",
+		1,
+		retryInterval,
+		timeout,
 	)
-	err = BuildTestData(oE)
-	require.NoError(t, err)
-	validateOutputEnvVars(oE.build)
+	require.NoError(t, err, "error on waiting for operator deployment")
 
-	createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-	validateController(t, ctx, f, oE.build, oE.buildRun)
-	deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-	// Run e2e tests for kaniko with custom context directory and Dockerfile name
-	oE = newOperatorEmulation(namespace,
-		"kaniko-custom-context-dockerfile",
-		"samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
-		"test/data/build_kaniko_cr_custom_context+dockerfile.yaml",
-		"test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml",
-	)
-	err = BuildTestData(oE)
-	require.NoError(t, err)
-	validateOutputEnvVars(oE.build)
-
-	createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-	validateController(t, ctx, f, oE.build, oE.buildRun)
-	deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-	// Run e2e tests for source2image
-	oE = newOperatorEmulation(namespace,
-		"example-build-s2i",
-		"samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml",
-		"samples/build/build_source-to-image_cr.yaml",
-		"samples/buildrun/buildrun_source-to-image_cr.yaml",
-	)
-	err = BuildTestData(oE)
-	require.NoError(t, err)
-	validateOutputEnvVars(oE.build)
-
-	createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-	validateController(t, ctx, f, oE.build, oE.buildRun)
-	deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-	// Run e2e tests for buildah
-	oE = newOperatorEmulation(namespace,
-		"example-build-buildah",
-		"samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
-		"samples/build/build_buildah_cr.yaml",
-		"samples/buildrun/buildrun_buildah_cr.yaml",
-	)
-	err = BuildTestData(oE)
-	require.NoError(t, err)
-	validateOutputEnvVars(oE.build)
-
-	createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-	validateController(t, ctx, f, oE.build, oE.buildRun)
-	deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-	// Run e2e tests for buildah with custom context directory and Dockerfile name
-	oE = newOperatorEmulation(namespace,
-		"buildah-custom-context-dockerfile",
-		"samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
-		"test/data/build_buildah_cr_custom_context+dockerfile.yaml",
-		"test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml",
-	)
-	err = BuildTestData(oE)
-	require.NoError(t, err)
-	validateOutputEnvVars(oE.build)
-
-	createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-	validateController(t, ctx, f, oE.build, oE.buildRun)
-	deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-	if validateRegistryEnvVars() {
-		// Run e2e tests for buildpacks v3
-		oE = newOperatorEmulation(namespace,
-			"example-build-buildpacks-v3",
-			"samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml",
-			"samples/build/build_buildpacks-v3_cr.yaml",
-			"samples/buildrun/buildrun_buildpacks-v3_cr.yaml",
-		)
-		err = BuildTestData(oE)
-		require.NoError(t, err)
-		validateOutputEnvVars(oE.build)
-
-		createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-		validateController(t, ctx, f, oE.build, oE.buildRun)
-		deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-		// Run e2e tests for buildpacks v3 with a namespaced scope
-		oE = newOperatorEmulation(namespace,
-			"example-build-buildpacks-v3-namespaced",
-			"samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml",
-			"samples/build/build_buildpacks-v3_namespaced_cr.yaml",
-			"samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml",
-		)
-		err = BuildTestData(oE)
-		require.NoError(t, err)
-		validateOutputEnvVars(oE.build)
-
-		oE.buildStrategy.SetNamespace(namespace)
-		createNamespacedBuildStrategy(t, ctx, f, oE.buildStrategy)
-		validateController(t, ctx, f, oE.build, oE.buildRun)
-		deleteBuildStrategy(t, f, oE.buildStrategy)
-	}
-
-	// Run e2e test cases for private repositories, only when
-	// env var TEST_WITH_PRIVATE_REPO is set.
-	if val, _ := os.LookupEnv(EnvVarEnablePrivateRepos); val == "true" {
-
-		// Run e2e tests for kaniko with private github repo
-		oE = newOperatorEmulation(namespace,
-			"example-build-kaniko-private-github",
-			"samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
-			"test/data/build_kaniko_cr_private_github.yaml",
-			"samples/buildrun/buildrun_kaniko_cr.yaml",
-		)
-		err = BuildTestData(oE)
-		require.NoError(t, err)
-
-		validateOutputEnvVars(oE.build)
-		// Validate env vars for private repos
-		validateSourceSecretRef(oE.build)
-		validateGithubURL(oE.build)
-
-		createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-		validateController(t, ctx, f, oE.build, oE.buildRun)
-		deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-		// Run e2e tests for kaniko with private gitlab repo
-		oE = newOperatorEmulation(namespace,
-			"example-build-kaniko-private-gitlab",
-			"samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
-			"test/data/build_kaniko_cr_private_gitlab.yaml",
-			"samples/buildrun/buildrun_kaniko_cr.yaml",
-		)
-		err = BuildTestData(oE)
-		require.NoError(t, err)
-		validateOutputEnvVars(oE.build)
-		// Validate env vars for private repos
-		validateSourceSecretRef(oE.build)
-		validateGitlabURL(oE.build)
-
-		createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-		validateController(t, ctx, f, oE.build, oE.buildRun)
-		deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-		// Run e2e tests for buildah with a private github repo
-		oE = newOperatorEmulation(namespace,
-			"example-build-buildah-private-github",
-			"samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
-			"test/data/build_buildah_cr_private_github.yaml",
-			"samples/buildrun/buildrun_buildah_cr.yaml",
-		)
-		err = BuildTestData(oE)
-		require.NoError(t, err)
-
-		validateOutputEnvVars(oE.build)
-		// Validate env vars for private repos
-		validateSourceSecretRef(oE.build)
-		validateGithubURL(oE.build)
-
-		createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-		validateController(t, ctx, f, oE.build, oE.buildRun)
-		deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-		// Run e2e tests for buildah with a private gitlab repo
-		oE = newOperatorEmulation(namespace,
-			"example-build-buildah-private-gitlab",
-			"samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
-			"test/data/build_buildah_cr_private_gitlab.yaml",
-			"samples/buildrun/buildrun_buildah_cr.yaml",
-		)
-		err = BuildTestData(oE)
-		require.NoError(t, err)
-
-		validateOutputEnvVars(oE.build)
-		// Validate env vars for private repos
-		validateSourceSecretRef(oE.build)
-		validateGitlabURL(oE.build)
-
-		createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-		validateController(t, ctx, f, oE.build, oE.buildRun)
-		deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-		if validateRegistryEnvVars() {
-			// Run e2e tests for buildpacks v3 with private github
-			oE = newOperatorEmulation(namespace,
-				"example-build-buildpacks-v3-private-github",
-				"samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml",
-				"test/data/build_buildpacks-v3_cr_private_github.yaml",
-				"samples/buildrun/buildrun_buildpacks-v3_cr.yaml",
-			)
-			err = BuildTestData(oE)
-			require.NoError(t, err)
-
-			validateOutputEnvVars(oE.build)
-			// Validate env vars for private repos
-			validateSourceSecretRef(oE.build)
-			validateGithubURL(oE.build)
-
-			createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-			validateController(t, ctx, f, oE.build, oE.buildRun)
-			deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-		}
-
-		// Run e2e tests for source2image with private github
-		oE = newOperatorEmulation(namespace,
-			"example-build-s2i-private-github",
-			"samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml",
-			"test/data/build_source-to-image_cr_private_github.yaml",
-			"samples/buildrun/buildrun_source-to-image_cr.yaml",
-		)
-		err = BuildTestData(oE)
-		require.NoError(t, err)
-
-		validateOutputEnvVars(oE.build)
-		// Validate env vars for private repos
-		validateSourceSecretRef(oE.build)
-		validateGithubURL(oE.build)
-
-		createClusterBuildStrategy(t, ctx, f, oE.clusterBuildStrategy)
-		validateController(t, ctx, f, oE.build, oE.buildRun)
-		deleteClusterBuildStrategy(t, f, oE.clusterBuildStrategy)
-
-	}
+	OperatorTests(t, ctx, f)
 }

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -1,0 +1,78 @@
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+)
+
+var regularTestCases = map[string]*SampleFiles{
+	"kaniko": {
+		ClusterBuildStrategy: "samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
+		Build:                "samples/build/build_kaniko_cr.yaml",
+		BuildRun:             "samples/buildrun/buildrun_kaniko_cr.yaml",
+	},
+	"s2i": {
+		ClusterBuildStrategy: "samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml",
+		Build:                "samples/build/build_source-to-image_cr.yaml",
+		BuildRun:             "samples/buildrun/buildrun_source-to-image_cr.yaml",
+	},
+	"buildah": {
+		ClusterBuildStrategy: "samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
+		Build:                "samples/build/build_buildah_cr.yaml",
+		BuildRun:             "samples/buildrun/buildrun_buildah_cr.yaml",
+	},
+	"buildpacks-v3": {
+		ClusterBuildStrategy: "samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml",
+		Build:                "samples/build/build_buildpacks-v3_cr.yaml",
+		BuildRun:             "samples/buildrun/buildrun_buildpacks-v3_cr.yaml",
+	},
+	"buildpacks-v3-namespaced": {
+		BuildStrategy: "samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml",
+		Build:         "samples/build/build_buildpacks-v3_namespaced_cr.yaml",
+		BuildRun:      "samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml",
+	},
+}
+
+var privateTestCases = map[string]*SampleFiles{
+	"private-github-kaniko": {
+		ClusterBuildStrategy: "samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
+		Build:                "test/data/build_kaniko_cr_private_github.yaml",
+		BuildRun:             "samples/buildrun/buildrun_kaniko_cr.yaml",
+	},
+	"private-gitlab-kaniko": {
+		ClusterBuildStrategy: "samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
+		Build:                "test/data/build_kaniko_cr_private_gitlab.yaml",
+		BuildRun:             "samples/buildrun/buildrun_kaniko_cr.yaml",
+	},
+	"private-github-buildah": {
+		ClusterBuildStrategy: "samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
+		Build:                "test/data/build_buildah_cr_private_github.yaml",
+		BuildRun:             "samples/buildrun/buildrun_buildah_cr.yaml",
+	},
+	"private-gitlab-buildah": {
+		ClusterBuildStrategy: "samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
+		Build:                "test/data/build_buildah_cr_private_gitlab.yaml",
+		BuildRun:             "samples/buildrun/buildrun_buildah_cr.yaml",
+	},
+	"private-github-buildpacks-v3": {
+		ClusterBuildStrategy: "samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml",
+		Build:                "test/data/build_buildpacks-v3_cr_private_github.yaml",
+		BuildRun:             "samples/buildrun/buildrun_buildpacks-v3_cr.yaml",
+	},
+	"private-github-s2i": {
+		ClusterBuildStrategy: "samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml",
+		Build:                "test/data/build_source-to-image_cr_private_github.yaml",
+		BuildRun:             "samples/buildrun/buildrun_source-to-image_cr.yaml",
+	},
+}
+
+func OperatorTests(t *testing.T, ctx *framework.TestCtx, f *framework.Framework) {
+	samplesTesting := NewSamplesTesting(t, ctx, f)
+	if os.Getenv(EnvVarEnablePrivateRepos) == "true" {
+		samplesTesting.TestAll(privateTestCases)
+	} else {
+		samplesTesting.TestAll(regularTestCases)
+	}
+}

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -15,6 +15,11 @@ var regularTestCases = map[string]*SampleFiles{
 		Build:                "samples/build/build_kaniko_cr.yaml",
 		BuildRun:             "samples/buildrun/buildrun_kaniko_cr.yaml",
 	},
+	"kaniko-custom-context-dockerfile": {
+		ClusterBuildStrategy: "samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
+		Build:                "test/data/build_kaniko_cr_custom_context+dockerfile.yaml",
+		BuildRun:             "test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml",
+	},
 	"s2i": {
 		ClusterBuildStrategy: "samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml",
 		Build:                "samples/build/build_source-to-image_cr.yaml",
@@ -24,6 +29,11 @@ var regularTestCases = map[string]*SampleFiles{
 		ClusterBuildStrategy: "samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
 		Build:                "samples/build/build_buildah_cr.yaml",
 		BuildRun:             "samples/buildrun/buildrun_buildah_cr.yaml",
+	},
+	"buildah-custom-context-dockerfile": {
+		ClusterBuildStrategy: "samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml",
+		Build:                "test/data/build_buildah_cr_custom_context+dockerfile.yaml",
+		BuildRun:             "test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml",
 	},
 	"buildpacks-v3": {
 		ClusterBuildStrategy: "samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml",

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -75,9 +75,8 @@ var privateTestCases = map[string]*SampleFiles{
 // OperatorTests execute test cases.
 func OperatorTests(t *testing.T, ctx *framework.TestCtx, f *framework.Framework) {
 	samplesTesting := NewSamplesTesting(t, ctx, f)
+	samplesTesting.TestAll(regularTestCases)
 	if os.Getenv(EnvVarEnablePrivateRepos) == "true" {
 		samplesTesting.TestAll(privateTestCases)
-	} else {
-		samplesTesting.TestAll(regularTestCases)
 	}
 }

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -7,6 +7,8 @@ import (
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 )
 
+// regularTestCases contains all data in samples, the strategy shipped by the operator are verified
+// during CI.
 var regularTestCases = map[string]*SampleFiles{
 	"kaniko": {
 		ClusterBuildStrategy: "samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
@@ -35,6 +37,8 @@ var regularTestCases = map[string]*SampleFiles{
 	},
 }
 
+// privateTestCases contains all test cases design to run against private git repositories, those
+// tests are enabled via environment variable ("TEST_PRIVATE_REPO").
 var privateTestCases = map[string]*SampleFiles{
 	"private-github-kaniko": {
 		ClusterBuildStrategy: "samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml",
@@ -68,6 +72,7 @@ var privateTestCases = map[string]*SampleFiles{
 	},
 }
 
+// OperatorTests execute test cases.
 func OperatorTests(t *testing.T, ctx *framework.TestCtx, f *framework.Framework) {
 	samplesTesting := NewSamplesTesting(t, ctx, f)
 	if os.Getenv(EnvVarEnablePrivateRepos) == "true" {

--- a/test/e2e/samples.go
+++ b/test/e2e/samples.go
@@ -1,0 +1,132 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	operator "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+)
+
+// SamplesTesting encapsulate the probes executed against sample files in build-operator.
+type SamplesTesting struct {
+	t   *testing.T           // testing instance
+	ctx *framework.TestCtx   // operator-sdk test context
+	f   *framework.Framework // operator-sdk test framework parameters
+	ns  string               // namespace
+}
+
+// SampleFiles group resources employed during each test interaction
+type SampleFiles struct {
+	ClusterBuildStrategy string // ClusterBuildStrategy file path
+	BuildStrategy        string // BuildStrategy file path
+	Build                string // Build file path
+	BuildRun             string // BuildRun  file path
+}
+
+// SecretName kubernetes secret resource name
+const SecretName = "e2e-registry"
+
+// amendOutputImage patch Build resource to include reference to container registry credentials
+// secret.
+func (s *SamplesTesting) amendOutputImage(b *operator.Build, imageRepo, repoSecret string) {
+	if imageRepo == "" || repoSecret == "" {
+		return
+	}
+	imageURL := fmt.Sprintf("%s:%s", imageRepo, b.Name)
+	b.Spec.Output = operator.Image{
+		ImageURL:  imageURL,
+		SecretRef: &v1.LocalObjectReference{Name: SecretName},
+	}
+	s.t.Logf("Amend object: name='%s', image-url='%s', secret='%s'", b.Name, imageURL, SecretName)
+}
+
+// amendSourceSecretRef patch Build source.SecretRef with secret name.
+func (s *SamplesTesting) amendSourceSecretRef(b *operator.Build, secretRef string) {
+	if secretRef == "" {
+		return
+	}
+	b.Spec.Source.SecretRef = &v1.LocalObjectReference{Name: secretRef}
+}
+
+// amendSourceURL patch Build source.URL with informed string.
+func (s *SamplesTesting) amendSourceURL(b *operator.Build, sourceURL string) {
+	if sourceURL == "" {
+		return
+	}
+	b.Spec.Source.URL = sourceURL
+}
+
+// amendBuild make changes on build object.
+func (s *SamplesTesting) amendBuild(identifier string, b *operator.Build) {
+	s.amendOutputImage(b, os.Getenv(EnvVarImageRepo), os.Getenv(EnvVarImageRepoSecret))
+	s.amendSourceSecretRef(b, os.Getenv(EnvVarSourceURLSecret))
+
+	if strings.Contains(identifier, "github") {
+		s.amendSourceURL(b, os.Getenv(EnvVarSourceURLGithub))
+	} else if strings.Contains(identifier, "gitlab") {
+		s.amendSourceURL(b, os.Getenv(EnvVarSourceURLGitlab))
+	}
+}
+
+// Test execute the test against the informed resources.
+func (s *SamplesTesting) Test(identifier string, files *SampleFiles) {
+	s.t.Logf("Testing '%s' using files '%#v'", identifier, files)
+
+	b, err := buildTestData(s.ns, identifier, files.Build)
+	require.NoError(s.t, err)
+	b.SetNamespace(s.ns)
+	s.amendBuild(identifier, b)
+
+	br, err := buildRunTestData(s.ns, identifier, files.BuildRun)
+	require.NoError(s.t, err)
+	br.SetNamespace(s.ns)
+
+	// on using an empty ClusterBuildStrategy it will fall back on namespaced BuildStrategy
+	if files.ClusterBuildStrategy != "" {
+		s.t.Log("Using a cluster wide build-strategy...")
+
+		cbs, err := clusterBuildStrategyTestData(files.ClusterBuildStrategy)
+		require.NoError(s.t, err)
+		cbs.SetNamespace(s.ns)
+
+		createClusterBuildStrategy(s.t, s.ctx, s.f, cbs)
+	} else {
+		s.t.Log("Using a namespaced build-strategy...")
+
+		bs, err := buildStrategyTestData(s.ns, files.BuildStrategy)
+		require.NoError(s.t, err)
+		bs.SetNamespace(s.ns)
+
+		createNamespacedBuildStrategy(s.t, s.ctx, s.f, bs)
+	}
+
+	validateController(s.t, s.ctx, s.f, b, br)
+}
+
+// TestAll iterate through test cases.
+func (s *SamplesTesting) TestAll(cases map[string]*SampleFiles) {
+	for identifier, files := range cases {
+		s.t.Logf("Running tests: '%s'", identifier)
+		s.Test(identifier, files)
+	}
+}
+
+// NewSamplesTesting instantiate SamplesTesting sharing testing components.
+func NewSamplesTesting(
+	t *testing.T,
+	ctx *framework.TestCtx,
+	f *framework.Framework,
+) *SamplesTesting {
+	ns, err := ctx.GetNamespace()
+	require.NoError(t, err)
+
+	// creating container registry secret during start
+	createContainerRegistrySecret(t, ctx, f)
+
+	return &SamplesTesting{t: t, ctx: ctx, f: f, ns: ns}
+}

--- a/test/e2e/samples.go
+++ b/test/e2e/samples.go
@@ -79,12 +79,10 @@ func (s *SamplesTesting) Test(identifier string, files *SampleFiles) {
 
 	b, err := buildTestData(s.ns, identifier, files.Build)
 	require.NoError(s.t, err)
-	b.SetNamespace(s.ns)
 	s.amendBuild(identifier, b)
 
 	br, err := buildRunTestData(s.ns, identifier, files.BuildRun)
 	require.NoError(s.t, err)
-	br.SetNamespace(s.ns)
 
 	// on using an empty ClusterBuildStrategy it will fall back on namespaced BuildStrategy
 	if files.ClusterBuildStrategy != "" {

--- a/test/e2e/validators.go
+++ b/test/e2e/validators.go
@@ -126,7 +126,7 @@ func validateController(
 	// Ensure that a TaskRun has been created and is in pending or running state
 	require.Eventually(t, func() bool {
 		generatedTaskRun, err := getTaskRun(f, testBuild, testBuildRun)
-		if err != nil {
+		if generatedTaskRun == nil || err != nil {
 			return false
 		}
 		conditionReason := generatedTaskRun.Status.Conditions[0].Reason

--- a/test/e2e/validators.go
+++ b/test/e2e/validators.go
@@ -133,8 +133,6 @@ func validateController(
 		return conditionReason == pendingStatus || conditionReason == runningStatus
 	}, 60*time.Second, 3*time.Second, "BuildRun is pending or running")
 
-	time.Sleep(15 * time.Second)
-
 	// Ensure BuildRun is in pending or running state
 	buildRunNsName := types.NamespacedName{Name: testBuildRun.Name, Namespace: ns}
 	err = f.Client.Get(goctx.TODO(), buildRunNsName, testBuildRun)
@@ -156,7 +154,7 @@ func validateController(
 		require.NoError(t, err)
 
 		return testBuildRun.Status.Succeeded == trueCondition
-	}, 600*time.Second, 5*time.Second, "BuildRun not succeeded")
+	}, 450*time.Second, 3*time.Second, "BuildRun not succeeded")
 }
 
 // readAndDecode read file path and decode.

--- a/test/e2e/validators.go
+++ b/test/e2e/validators.go
@@ -144,7 +144,7 @@ func validateController(
 		require.NoError(t, err)
 
 		return testBuildRun.Status.Reason == runningStatus
-	}, 60*time.Second, 3*time.Second, "BuildRun not running")
+	}, 180*time.Second, 3*time.Second, "BuildRun not running")
 
 	// Ensure that eventually the Build moves to Succeeded.
 	require.Eventually(t, func() bool {
@@ -152,7 +152,7 @@ func validateController(
 		require.NoError(t, err)
 
 		return testBuildRun.Status.Succeeded == trueCondition
-	}, 300*time.Second, 10*time.Second, "BuildRun not succeeded")
+	}, 600*time.Second, 5*time.Second, "BuildRun not succeeded")
 }
 
 // readAndDecode read file path and decode.


### PR DESCRIPTION
This pull-request improves end-to-end tests to use a external container registry. Container images built for each test-case will be stored at [quay.io repository](https://quay.io/repository/redhat-developer/build-e2e).

End-to-end test infrastructure is centralised in a single location, the same for test execution. Later on we can include nobs to enable/disable tests via parameters (#100).

## How to Test

Tests are running on Travis-CI currently, therefore to execute them locally please run:

```sh
make test-e2e ...
```

The details of environment variables and further examples are updated on `HACK.md`.