### PR TITLE
Add +kubebuilder for build CRD

### DIFF
--- a/deploy/crds/build.dev_builds_crd.yaml
+++ b/deploy/crds/build.dev_builds_crd.yaml
@@ -198,11 +198,12 @@ spec:
         status:
           description: BuildStatus defines the observed state of Build
           properties:
+            reason:
+              description: The reason of the registered Build, either an error or
+                succeed message
+              type: string
             registered:
               description: The Register status of the Build
-              type: string
-            reason:
-              description: The reason of the registered Build, either an error or succeed message
               type: string
           type: object
       type: object

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -62,7 +62,7 @@ type Image struct {
 
 // BuildStatus defines the observed state of Build
 type BuildStatus struct {
-	// The Registered status of the TaskRun
+	// The Register status of the Build
 	Registered corev1.ConditionStatus `json:"registered,omitempty"`
 
 	// The reason of the registered Build, either an error or succeed message
@@ -74,6 +74,8 @@ type BuildStatus struct {
 // Build is the Schema for the builds API
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=builds,scope=Namespaced
+// +kubebuilder:printcolumn:name="Registered",type="string",JSONPath=".status.registered",description="The register status of the Build"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.reason",description="The reason of the registered Build, either an error or succeed message"
 // +kubebuilder:printcolumn:name="BuildStrategyKind",type="string",JSONPath=".spec.strategy.kind",description="The BuildStrategy type which is used for this Build"
 // +kubebuilder:printcolumn:name="BuildStrategyName",type="string",JSONPath=".spec.strategy.name",description="The BuildStrategy name which is used for this Build"
 // +kubebuilder:printcolumn:name="CreationTime",type="date",JSONPath=".metadata.creationTimestamp",description="The create time of this Build"


### PR DESCRIPTION
Some updates(e.g. `additionalPrinterColumns `) in `build.dev_builds_crd.yaml` will be overwritten using `operator-sdk generate crds`.
Therefore, we also need the comments using the `+kubebuilder`