### PR TITLE
fix BuildStrategyKind is nil issue

### DIFF
--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -123,17 +123,24 @@ func (r *ReconcileBuild) Reconcile(request reconcile.Request) (reconcile.Result,
 }
 
 func (r *ReconcileBuild) validateStrategyRef(s *build.StrategyRef, ns string) error {
-	switch *s.Kind {
-	case build.NamespacedBuildStrategyKind:
+	if s.Kind != nil {
+		switch *s.Kind {
+		case build.NamespacedBuildStrategyKind:
+			if err := r.validateBuildStrategy(s.Name, ns); err != nil {
+				return err
+			}
+		case build.ClusterBuildStrategyKind:
+			if err := r.validateClusterBuildStrategy(s.Name); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown strategy %v", *s.Kind)
+		}
+	} else {
+		log.Info("BuildStrategy kind is nil, use default NamespacedBuildStrategyKind")
 		if err := r.validateBuildStrategy(s.Name, ns); err != nil {
 			return err
 		}
-	case build.ClusterBuildStrategyKind:
-		if err := r.validateClusterBuildStrategy(s.Name); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("unknown strategy %v", *s.Kind)
 	}
 	return nil
 }

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -60,6 +60,24 @@ func (c *Catalog) BuildWithBuildStrategy(name string, ns string, strategyName st
 	}
 }
 
+// BuildWithNilBuildStrategyKind gives you an Build CRD with nil build strategy kind
+func (c *Catalog) BuildWithNilBuildStrategyKind(name string, ns string, strategyName string) *build.Build {
+	return &build.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: build.BuildSpec{
+			Source: build.GitSource{
+				URL: "foobar",
+			},
+			StrategyRef: &build.StrategyRef{
+				Name: strategyName,
+			},
+		},
+	}
+}
+
 // ClusterBuildStrategyList to support tests
 func (c *Catalog) ClusterBuildStrategyList(name string) *build.ClusterBuildStrategyList {
 	return &build.ClusterBuildStrategyList{


### PR DESCRIPTION
Fix issue: https://github.com/redhat-developer/build/issues/146

I have verified this modification and e2e test is also passed. Now, when I apply a `build` with a nil `spec.strategy.kind`, then it will use the default  NamespacedBuildStrategyKind `BuildStrategy`. And also build process can come up  normally.

Below is the step of my verification:
- apply a `build` and `buildrun` with nil `spec.strategy.kind`
```
---
apiVersion: build.dev/v1alpha1
kind: Build
metadata:
  name: kaniko-golang-build-zoe-spec
spec:
  source:
    url: https://github.com/sbose78/taxi
  strategy:
    name: kaniko
  dockerfile: Dockerfile
  resources:
    limits:
      cpu: "500m"
      memory: "1Gi"
  output:
    image: us.icr.io/zoe_namespace/test-spec
    credentials:
      name: icr-knbuild
```
```
apiVersion: build.dev/v1alpha1
kind: BuildRun
metadata:
  name: kaniko-golang-buildrun-zoe-spec
spec:
  buildRef:
    #apiVersion: "v1"
    name: kaniko-golang-build-zoe-spec 
  resources:
    limits:
      cpu: "1"
```
- Check the controller log
```
{"level":"info","ts":1587612850.3574502,"logger":"controller_build","msg":"Reconciling Build","Request.Namespace":"default","Request.Name":"kaniko-golang-build-zoe-spec"}
{"level":"info","ts":1587612850.5581179,"logger":"controller_build","msg":"BuildStrategy kind is nil, use default NamespacedBuildStrategyKind"}
{"level":"info","ts":1587612860.296682,"logger":"controller_buildrun","msg":"Reconciling BuildRun","Request.Namespace":"default","Request.Name":"kaniko-golang-buildrun-zoe-spec"}
```
- Check the status of build and buildrun
```
kubectl get build
NAME                           REGISTERED   REASON      BUILDSTRATEGYKIND   BUILDSTRATEGYNAME   CREATIONTIME
kaniko-golang-build-zoe-spec   True         Succeeded                       kaniko              95s
```
```
kubectl get buildrun
NAME                              SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
kaniko-golang-buildrun-zoe-spec   True        Succeeded   94s         30s
```
```
kubectl get pod
NAME                                              READY   STATUS      RESTARTS   AGE
kaniko-golang-buildrun-zoe-spec-w86kv-pod-bt84p   0/4     Completed   0          97s
```

Next is the result of `e2e` test:
```
INFO[0000] Testing operator locally.                    
time="2020-04-22T23:14:41-04:00" level=info msg="Started local operator"
=== RUN   TestBuild
=== RUN   TestBuild/build-group
=== RUN   TestBuild/build-group/Build_e2e_tests
=== PAUSE TestBuild/build-group/Build_e2e_tests
=== CONT  TestBuild/build-group/Build_e2e_tests
--- PASS: TestBuild (521.63s)
    --- PASS: TestBuild/build-group (0.00s)
        --- PASS: TestBuild/build-group/Build_e2e_tests (510.42s)
            main_test.go:69: Initialized cluster resources
            wait_util.go:48: Operator is running locally; skip waitForDeployment
            client.go:62: resource type ClusterBuildStrategy with namespace/name (/kaniko) created
            client.go:62: resource type Build with namespace/name (default/example-build-kaniko) created
            client.go:62: resource type BuildRun with namespace/name (default/example-build-kaniko) created
            client.go:62: resource type ClusterBuildStrategy with namespace/name (/kaniko) created
            client.go:62: resource type Build with namespace/name (default/kaniko-custom-context-dockerfile) created
            client.go:62: resource type BuildRun with namespace/name (default/kaniko-custom-context-dockerfile) created
            client.go:62: resource type ClusterBuildStrategy with namespace/name (/source-to-image) created
            client.go:62: resource type Build with namespace/name (default/example-build-s2i) created
            client.go:62: resource type BuildRun with namespace/name (default/example-build-s2i) created
            client.go:62: resource type ClusterBuildStrategy with namespace/name (/buildah) created
            client.go:62: resource type Build with namespace/name (default/example-build-buildah) created
            client.go:62: resource type BuildRun with namespace/name (default/example-build-buildah) created
            client.go:62: resource type ClusterBuildStrategy with namespace/name (/buildah) created
            client.go:62: resource type Build with namespace/name (default/buildah-custom-context-dockerfile) created
            client.go:62: resource type BuildRun with namespace/name (default/buildah-custom-context-dockerfile) created
            client.go:62: resource type ClusterBuildStrategy with namespace/name (/buildpacks-v3) created
            client.go:62: resource type Build with namespace/name (default/example-build-buildpacks-v3) created
            client.go:62: resource type BuildRun with namespace/name (default/example-build-buildpacks-v3) created
            client.go:62: resource type BuildStrategy with namespace/name (default/buildpacks-v3) created
            client.go:62: resource type Build with namespace/name (default/example-build-buildpacks-v3-namespaced) created
            client.go:62: resource type BuildRun with namespace/name (default/example-build-buildpacks-v3-namespaced) created
PASS
```
Below is the unit test result:
```
Running Suite: Build Suite
==========================
Random Seed: 1587628876
Will run 8 of 8 specs

••••••••
Ran 8 of 8 Specs in 0.001 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok      github.com/redhat-developer/build/pkg/controller/build  0.284s
```