### PR TITLE
convert spec.buildRef.name to be required instead of optional

### DIFF
--- a/deploy/crds/build.dev_buildruns_crd.yaml
+++ b/deploy/crds/build.dev_buildruns_crd.yaml
@@ -60,6 +60,8 @@ spec:
                 name:
                   description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                   type: string
+              required:
+              - name
               type: object
             resources:
               description: 'Compute Resources required by the build container which

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -53,7 +53,7 @@ type BuildRunStatus struct {
 // BuildRef can be used to refer to a specific instance of a Build.
 type BuildRef struct {
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 	// API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`


### PR DESCRIPTION
Fix issue: https://github.com/redhat-developer/build/issues/141

For `buildRun` spec, the definition of `spec.buildRef.name` shouldn't be nil. Otherwise, the build process won't come up because of `Failed to get Build from BuildRun`.

For this modification, I have checked, if I use changed buildRun crd, then when I apply a buildRun with nil buildRef name:
```
apiVersion: build.dev/v1alpha1
kind: BuildRun
metadata:
  name: kaniko-golang-buildrun-zoe-spec
spec:
  buildRef:
    apiVersion: "v1"
  resources:
    limits:
      cpu: "1"

```
It will fail and return below error:
```
kubectl apply -f buildrun_kaniko_cr_spec.yaml
The BuildRun "kaniko-golang-buildrun-zoe-spec" is invalid: spec.buildRef.name: Required value
```