### PR TITLE
Define k8s node version

### DIFF
--- a/hack/install-kind.sh
+++ b/hack/install-kind.sh
@@ -5,16 +5,25 @@
 
 set -eu
 
+# kind version
+KIND_VERSION="${KIND_VERSION:-v0.7.0}"
+
 if [ ! -f "${GOPATH}/bin/kind" ] ; then
     echo "# Installing KinD..."
-    go get sigs.k8s.io/kind
+    go get sigs.k8s.io/kind@${KIND_VERSION}
 fi
+
+# print kind version
+kind --version
 
 # kind cluster name
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 
+# kind cluster version
+KIND_CLUSTER_VERSION="${KIND_CLUSTER_VERSION:-v1.17.0}"
+
 echo "# Creating a new Kubernetes cluster..."
-kind create cluster --quiet --name="${KIND_CLUSTER_NAME}" --wait=120s
+kind create cluster --quiet --name="${KIND_CLUSTER_NAME}" --image="kindest/node:${KIND_CLUSTER_VERSION}" --wait=120s
 
 echo "# Using KinD context..."
 kubectl config use-context "kind-kind"


### PR DESCRIPTION
kind releases version 0.8.0 recently which changes the default k8s node version to 1.18. K8s v1.18 includes the managedFields field for server-side apply, see https://kubernetes.io/blog/2020/04/01/kubernetes-1.18-feature-server-side-apply-beta-2/. This breaks our build. See https://travis-ci.com/github/redhat-developer/build/builds/163723206.

The code change introduces an environment variable `KIND_CLUSTER_VERSION` in `install-kind.sh` with a default `v1.17.5`. Creating PR to see if this builds successfully.
