### PR TITLE
Add initial unit tests for buildstrategy for test coverage

### DIFF
--- a/pkg/controller/buildstrategy/buildstrategy_controller.go
+++ b/pkg/controller/buildstrategy/buildstrategy_controller.go
@@ -17,11 +17,11 @@ var log = logf.Log.WithName("controller_buildstrategy")
 // Add creates a new BuildStrategy Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+	return add(mgr, NewReconciler(mgr))
 }
 
-// newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+// NewReconciler returns a new reconcile.Reconciler
+func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileBuildStrategy{client: mgr.GetClient(), scheme: mgr.GetScheme()}
 }
 

--- a/pkg/controller/buildstrategy/buildstrategy_controller_test.go
+++ b/pkg/controller/buildstrategy/buildstrategy_controller_test.go
@@ -1,0 +1,43 @@
+package buildstrategy_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	buildstrategyController "github.com/redhat-developer/build/pkg/controller/buildstrategy"
+	"github.com/redhat-developer/build/pkg/controller/fakes"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Reconcile BuildStrategy", func() {
+	var (
+		manager                      *fakes.FakeManager
+		reconciler                   reconcile.Reconciler
+		request                      reconcile.Request
+		namespace, buildStrategyName string
+	)
+
+	BeforeEach(func() {
+		buildStrategyName = "buildah"
+		namespace = "build-examples"
+
+		// Fake the manager and get a reconcile Request
+		manager = &fakes.FakeManager{}
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: buildStrategyName, Namespace: namespace}}
+	})
+
+	JustBeforeEach(func() {
+		// Reconcile
+		reconciler = buildstrategyController.NewReconciler(manager)
+	})
+
+	Describe("Reconcile", func() {
+		Context("when request a new BuildStrategy", func() {
+			It("succeed without any error", func() {
+				result, err := reconciler.Reconcile(request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(reconcile.Result{}).To(Equal(result))
+			})
+		})
+	})
+})

--- a/pkg/controller/buildstrategy/buildstrategy_suite_test.go
+++ b/pkg/controller/buildstrategy/buildstrategy_suite_test.go
@@ -1,0 +1,13 @@
+package buildstrategy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBuild(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BuildStrategy Suite")
+}

--- a/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go
+++ b/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go
@@ -17,11 +17,11 @@ var log = logf.Log.WithName("controller_clusterbuildstrategy")
 // Add creates a new ClusterBuildStrategy Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+	return add(mgr, NewReconciler(mgr))
 }
 
-// newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+// NewReconciler returns a new reconcile.Reconciler
+func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileClusterBuildStrategy{client: mgr.GetClient(), scheme: mgr.GetScheme()}
 }
 

--- a/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller_test.go
+++ b/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller_test.go
@@ -1,0 +1,42 @@
+package clusterbuildstrategy_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	clusterbuildstrategyController "github.com/redhat-developer/build/pkg/controller/clusterbuildstrategy"
+	"github.com/redhat-developer/build/pkg/controller/fakes"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Reconcile ClusterBuildStrategy", func() {
+	var (
+		manager                      *fakes.FakeManager
+		reconciler                   reconcile.Reconciler
+		request                      reconcile.Request
+		buildStrategyName            string
+	)
+
+	BeforeEach(func() {
+		buildStrategyName = "kaniko"
+
+		// Fake the manager and get a reconcile Request
+		manager = &fakes.FakeManager{}
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: buildStrategyName}}
+	})
+
+	JustBeforeEach(func() {
+		// Reconcile
+		reconciler = clusterbuildstrategyController.NewReconciler(manager)
+	})
+
+	Describe("Reconcile", func() {
+		Context("when request a new ClusterBuildStrategy", func() {
+			It("succeed without any error", func() {
+				result, err := reconciler.Reconcile(request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(reconcile.Result{}).To(Equal(result))
+			})
+		})
+	})
+})

--- a/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_suite_test.go
+++ b/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_suite_test.go
@@ -1,0 +1,13 @@
+package clusterbuildstrategy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBuild(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ClusterBuildStrategy Suite")
+}


### PR DESCRIPTION
Although we don't have logic in buildstartegy and clusterbuildstrategy controller, but the controllers are generated and located in the `pkg` package.

We need to ensure our test coverage is enough for the production. So we have to add at least one unit test to test its basic function.

If we want to add more features in two controllers, let us continue enriching the test cases in the unit test logic.

What I added in this PR:
- Add one basic unit test for buildstrategy controller
- Add one basic unit test for clusterbuildstrategy controller