### PR TITLE
Tekton Pipelines v0.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ OPERATOR_SDK_EXTRA_ARGS ?= --debug
 TEST_NAMESPACE ?= default
 
 # CI: tekton pipelines operator version
-TEKTON_VERSION ?= v0.10.1
+TEKTON_VERSION ?= v0.11.0
 # CI: operator-sdk version
 SDK_VERSION ?= v0.15.2
 

--- a/hack/install-tekton.sh
+++ b/hack/install-tekton.sh
@@ -5,10 +5,10 @@
 
 set -eu
 
-TEKTON_VERSION="${TEKTON_VERSION:-v0.10.1}"
+TEKTON_VERSION="${TEKTON_VERSION:-v0.11.0}"
 
-TEKTON_HOST="storage.googleapis.com"
-TEKTON_HOST_PATH="tekton-releases/pipeline/previous"
+TEKTON_HOST="github.com"
+TEKTON_HOST_PATH="tektoncd/pipeline/releases/download"
 
 echo "# Deploying Tekton Pipelines Operator '${TEKTON_VERSION}'"
 


### PR DESCRIPTION
Fixes #144. After merging #166, we are able to use Tekton `v0.11.0` on CI.