### PR TITLE
Remove node parameter to show the test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,6 @@ test-unit:
 		-randomizeAllSpecs \
 		-randomizeSuites \
 		-failOnPending \
-		-nodes=4 \
 		-compilers=2 \
 		-slowSpecThreshold=240 \
 		-race \


### PR DESCRIPTION
In current unit test (`make test`), we use `-node` parameter, but with this parameter, the test coverage cannot show correctly:
https://travis-ci.org/github/redhat-developer/build/builds/683705277#L2116-L2118

After remove it, the test coverage can be shown:
```
[1588828474] BuildRun Suite - 10/10 specs •••••••••• SUCCESS! 5.558302ms PASS
coverage: 72.1% of statements
[1588828474] Build Suite - 8/8 specs •••••••• SUCCESS! 1.378707ms PASS
coverage: 70.2% of statements
[1588828474] Controllers Suite - 0/0 specs  SUCCESS! 420.789µs PASS
coverage: 50.0% of statements
```

And for unit test, the speed of single node or multiple nodes are similiar, no too much different, but we need to show the test coverage in our result for audit.