### PR TITLE
Migrate taskrun tests to ginkgo

### DIFF
--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -160,7 +160,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 			return reconcile.Result{}, err
 		}
 		if buildStrategy != nil {
-			generatedTaskRun, err = generateTaskRun(build, buildRun, serviceAccount.Name, buildStrategy.Spec.BuildSteps)
+			generatedTaskRun, err = GenerateTaskRun(build, buildRun, serviceAccount.Name, buildStrategy.Spec.BuildSteps)
 			if err != nil {
 				updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
 				return reconcile.Result{}, fmt.Errorf("errors: %v %v", err, updateErr)
@@ -172,7 +172,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 			return reconcile.Result{}, err
 		}
 		if clusterBuildStrategy != nil {
-			generatedTaskRun, err = generateTaskRun(build, buildRun, serviceAccount.Name, clusterBuildStrategy.Spec.BuildSteps)
+			generatedTaskRun, err = GenerateTaskRun(build, buildRun, serviceAccount.Name, clusterBuildStrategy.Spec.BuildSteps)
 			if err != nil {
 				updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
 				return reconcile.Result{}, fmt.Errorf("errors: %v %v", err, updateErr)

--- a/pkg/controller/buildrun/generate_taskrun.go
+++ b/pkg/controller/buildrun/generate_taskrun.go
@@ -44,7 +44,7 @@ func getStringTransformations(fullText string) string {
 	return fullText
 }
 
-func generateTaskSpec(build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun, buildSteps []buildv1alpha1.BuildStep) (*v1beta1.TaskSpec, error) {
+func GenerateTaskSpec(build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun, buildSteps []buildv1alpha1.BuildStep) (*v1beta1.TaskSpec, error) {
 
 	generatedTaskSpec := v1beta1.TaskSpec{
 		Resources: &v1beta1.TaskResources{
@@ -163,14 +163,14 @@ func generateTaskSpec(build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildR
 	return &generatedTaskSpec, nil
 }
 
-func generateTaskRun(build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun, serviceAccountName string, buildSteps []buildv1alpha1.BuildStep) (*v1beta1.TaskRun, error) {
+func GenerateTaskRun(build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun, serviceAccountName string, buildSteps []buildv1alpha1.BuildStep) (*v1beta1.TaskRun, error) {
 
 	revision := "master"
 	if build.Spec.Source.Revision != nil {
 		revision = *build.Spec.Source.Revision
 	}
 
-	taskSpec, err := generateTaskSpec(build, buildRun, buildSteps)
+	taskSpec, err := GenerateTaskSpec(build, buildRun, buildSteps)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/buildrun/generate_taskrun_test.go
+++ b/pkg/controller/buildrun/generate_taskrun_test.go
@@ -1,49 +1,57 @@
-package buildrun
+package buildrun_test
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
-	"testing"
 
-	"k8s.io/apimachinery/pkg/api/resource"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	buildv1alpha1 "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
-	"github.com/stretchr/testify/assert"
+	buildrunCtl "github.com/redhat-developer/build/pkg/controller/buildrun"
 	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	buildah    = "buildah"
-	buildpacks = "buildpacks-v3"
-	url        = "https://github.com/sbose78/taxi"
-)
+var _ = Describe("GenerateTaskrun", func() {
 
-func TestGenerateTaskSpec(t *testing.T) {
+	var (
+		build                                *buildv1alpha1.Build
+		buildRun                             *buildv1alpha1.BuildRun
+		buildStrategy                        *buildv1alpha1.BuildStrategy
+		builderImage                         *buildv1alpha1.Image
+		clusterBuildStrategy                 buildv1alpha1.BuildStrategyKind
+		dockerfile, buildah, buildpacks, url string
+	)
 
-	dockerfile := "Dockerfile"
-	builderImage := buildv1alpha1.Image{
-		ImageURL: "quay.io/builder/image",
-	}
-	buildStrategy := buildv1alpha1.ClusterBuildStrategyKind
-	truePtr := true
+	BeforeEach(func() {
+		buildah = "buildah"
+		buildpacks = "buildpacks-v3"
+		url = "https://github.com/sbose78/taxi"
+		dockerfile = "Dockerfile"
+		clusterBuildStrategy = buildv1alpha1.ClusterBuildStrategyKind
+	})
 
-	type args struct {
-		build         *buildv1alpha1.Build
-		buildRun      *buildv1alpha1.BuildRun
-		buildStrategy *buildv1alpha1.BuildStrategy
-	}
-	tests := []struct {
-		name string
-		args args
-		want *v1beta1.TaskSpec
-	}{
-		{
-			"taskSpec generation",
-			args{
-				build: &buildv1alpha1.Build{
+	Describe("Generate the TaskSpec", func() {
+		var (
+			truePtr               bool
+			expectedCommandOrArg  []string
+			expectedResourceOrArg corev1.ResourceRequirements
+			got                   *v1beta1.TaskSpec
+			err                   error
+		)
+		BeforeEach(func() {
+			builderImage = &buildv1alpha1.Image{
+				ImageURL: "quay.io/builder/image",
+			}
+			truePtr = true
+		})
+
+		Context("when the task spec is generated", func() {
+			BeforeEach(func() {
+				build = &buildv1alpha1.Build{
 					ObjectMeta: metav1.ObjectMeta{Name: buildah},
 					Spec: buildv1alpha1.BuildSpec{
 						Source: buildv1alpha1.GitSource{
@@ -51,10 +59,10 @@ func TestGenerateTaskSpec(t *testing.T) {
 						},
 						StrategyRef: &buildv1alpha1.StrategyRef{
 							Name: buildah,
-							Kind: &buildStrategy,
+							Kind: &clusterBuildStrategy,
 						},
 						Dockerfile:   &dockerfile,
-						BuilderImage: &builderImage,
+						BuilderImage: builderImage,
 						Resources: &corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -66,8 +74,9 @@ func TestGenerateTaskSpec(t *testing.T) {
 							},
 						},
 					},
-				},
-				buildRun: &buildv1alpha1.BuildRun{
+				}
+
+				buildRun = &buildv1alpha1.BuildRun{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: buildah + "-run",
 					},
@@ -76,12 +85,13 @@ func TestGenerateTaskSpec(t *testing.T) {
 							Name: buildah,
 						},
 					},
-				},
-				buildStrategy: &buildv1alpha1.BuildStrategy{
+				}
+
+				buildStrategy = &buildv1alpha1.BuildStrategy{
 					ObjectMeta: metav1.ObjectMeta{Name: buildah},
 					Spec: buildv1alpha1.BuildStrategySpec{
 						BuildSteps: []buildv1alpha1.BuildStep{
-							buildv1alpha1.BuildStep{
+							{
 								Container: corev1.Container{
 									Name:       "build",
 									Image:      "$(build.builder.image)",
@@ -103,7 +113,7 @@ func TestGenerateTaskSpec(t *testing.T) {
 									},
 								},
 							},
-							buildv1alpha1.BuildStep{
+							{
 								Container: corev1.Container{
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -119,76 +129,71 @@ func TestGenerateTaskSpec(t *testing.T) {
 							},
 						},
 					},
-				},
-			},
-			&v1beta1.TaskSpec{}, // not using it for now
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := generateTaskSpec(tt.args.build, tt.args.buildRun, tt.args.buildStrategy.Spec.BuildSteps)
-			expectedCommandOrArg := []string{
-				"buildah", "bud", "--tls-verify=false", "--layers", "-f", fmt.Sprintf("$(inputs.params.%s)", inputParamDockerfile), "-t", "$(outputs.resources.image.url)", fmt.Sprintf("$(inputs.params.%s)", inputParamPathContext),
-			}
+				}
 
-			expectedResourceOrArg := corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("500m"),
-					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("500m"),
-					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
+				expectedCommandOrArg = []string{
+					"buildah", "bud", "--tls-verify=false", "--layers", "-f", fmt.Sprintf("$(inputs.params.%s)", "DOCKERFILE"), "-t", "$(outputs.resources.image.url)", fmt.Sprintf("$(inputs.params.%s)", "PATH_CONTEXT"),
+				}
 
-			assert.True(t, reflect.DeepEqual(err, nil))
+				expectedResourceOrArg = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				}
+			})
 
-			// ensure IMAGE is replaced by builder image when needed.
-			assert.Equal(t, fmt.Sprintf("$(inputs.params.%s)", inputParamBuilderImage), got.Steps[0].Container.Image)
+			JustBeforeEach(func() {
+				got, err = buildrunCtl.GenerateTaskSpec(build, buildRun, buildStrategy.Spec.BuildSteps)
+				Expect(err).To(BeNil())
+			})
 
-			// ensure command replacements happen when needed
-			assert.True(t, reflect.DeepEqual(got.Steps[0].Container.Command, expectedCommandOrArg))
+			It("should ensure IMAGE is replaced by builder image when needed.", func() {
+				Expect(got.Steps[0].Container.Image).To(Equal(fmt.Sprintf("$(inputs.params.%s)", "BUILDER_IMAGE")))
+			})
 
-			// ensure resource replacements happen when needed
-			assert.True(t, reflect.DeepEqual(got.Steps[0].Container.Resources, expectedResourceOrArg))
+			It("should ensure command replacements happen when needed", func() {
+				Expect(got.Steps[0].Container.Command).To(Equal(expectedCommandOrArg))
+			})
 
-			// ensure arg replacements happen when needed.
-			assert.True(t, reflect.DeepEqual(expectedCommandOrArg, got.Steps[0].Container.Args))
+			It("should ensure resource replacements happen when needed", func() {
+				Expect(got.Steps[0].Container.Resources).To(Equal(expectedResourceOrArg))
+			})
 
-			// Ensure top level volumes are populated.
-			assert.Equal(t, 2, len(got.Volumes))
+			It("should ensure arg replacements happen when needed", func() {
+				Expect(got.Steps[0].Container.Args).To(Equal(expectedCommandOrArg))
+			})
+
+			It("should ensure top level volumes are populated", func() {
+				Expect(len(got.Volumes)).To(Equal(2))
+			})
 		})
-	}
-}
+	})
 
-func TestGenerateTaskRun(t *testing.T) {
+	Describe("Generate the TaskRun", func() {
+		var (
+			namespace, contextDir, revision, outputPath, serviceAccountName string
+			got                                                             *v1beta1.TaskRun
+			err                                                             error
+		)
+		BeforeEach(func() {
+			namespace = "build-test"
+			contextDir = "src"
+			revision = "master"
+			builderImage = &buildv1alpha1.Image{
+				ImageURL: "heroku/buildpacks:18",
+			}
+			outputPath = "image-registry.openshift-image-registry.svc:5000/example/buildpacks-app"
+			serviceAccountName = buildpacks + "-serviceaccount"
+		})
 
-	namespace := "build-test"
-	dockerfile := "Dockerfile"
-	contextDir := "src"
-	revision := "master"
-	builderImage := buildv1alpha1.Image{
-		ImageURL: "heroku/buildpacks:18",
-	}
-	clustertBuildStrategy := buildv1alpha1.ClusterBuildStrategyKind
-	outputPath := "image-registry.openshift-image-registry.svc:5000/example/buildpacks-app"
-	serviceAccountName := buildpacks + "-serviceaccount"
-
-	type args struct {
-		build         *buildv1alpha1.Build
-		buildRun      *buildv1alpha1.BuildRun
-		buildStrategy *buildv1alpha1.BuildStrategy
-	}
-	tests := []struct {
-		name string
-		args args
-		want *v1beta1.TaskRun
-	}{
-		{
-			"taskrun generation by default",
-			args{
-				build: &buildv1alpha1.Build{
+		Context("when the taskrun is generated by default", func() {
+			BeforeEach(func() {
+				build = &buildv1alpha1.Build{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      buildah,
 						Namespace: namespace,
@@ -204,8 +209,8 @@ func TestGenerateTaskRun(t *testing.T) {
 							ImageURL: outputPath,
 						},
 					},
-				},
-				buildRun: &buildv1alpha1.BuildRun{
+				}
+				buildRun = &buildv1alpha1.BuildRun{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      buildah + "-run",
 						Namespace: namespace,
@@ -228,12 +233,12 @@ func TestGenerateTaskRun(t *testing.T) {
 							Name: &serviceAccountName,
 						},
 					},
-				},
-				buildStrategy: &buildv1alpha1.BuildStrategy{
+				}
+				buildStrategy = &buildv1alpha1.BuildStrategy{
 					ObjectMeta: metav1.ObjectMeta{Name: buildah},
 					Spec: buildv1alpha1.BuildStrategySpec{
 						BuildSteps: []buildv1alpha1.BuildStep{
-							buildv1alpha1.BuildStep{
+							{
 								Container: corev1.Container{
 									Name:       "build",
 									Image:      "$(build.builder.image)",
@@ -251,14 +256,67 @@ func TestGenerateTaskRun(t *testing.T) {
 							},
 						},
 					},
-				},
-			},
-			&v1beta1.TaskRun{}, // not using it for now
-		},
-		{
-			"taskrun generation by special settings",
-			args{
-				build: &buildv1alpha1.Build{
+				}
+			})
+
+			JustBeforeEach(func() {
+				got, err = buildrunCtl.GenerateTaskRun(build, buildRun, serviceAccountName, buildStrategy.Spec.BuildSteps)
+				Expect(err).To(BeNil())
+			})
+
+			It("should ensure generated TaskRun's basic information are correct", func() {
+				Expect(strings.Contains(got.GenerateName, buildRun.Name+"-")).To(Equal(true))
+				Expect(got.Namespace).To(Equal(namespace))
+				Expect(got.Spec.ServiceAccountName).To(Equal(buildpacks + "-serviceaccount"))
+				Expect(got.Labels[buildv1alpha1.LabelBuild]).To(Equal(build.Name))
+				Expect(got.Labels[buildv1alpha1.LabelBuildRun]).To(Equal(buildRun.Name))
+			})
+
+			It("should ensure generated TaskRun's input and output resources are correct", func() {
+				inputResources := got.Spec.Resources.Inputs
+				for _, inputResource := range inputResources {
+					Expect(inputResource.ResourceSpec.Type).To(Equal(v1beta1.PipelineResourceTypeGit))
+					params := inputResource.ResourceSpec.Params
+					for _, param := range params {
+						if param.Name == "url" {
+							Expect(param.Value).To(Equal(url))
+						}
+						if param.Name == "revision" {
+							Expect(param.Value).To(Equal(revision))
+						}
+					}
+				}
+
+				outputResources := got.Spec.Resources.Outputs
+				for _, outputResource := range outputResources {
+					Expect(outputResource.ResourceSpec.Type).To(Equal(v1beta1.PipelineResourceTypeImage))
+					params := outputResource.ResourceSpec.Params
+					for _, param := range params {
+						if param.Name == "url" {
+							Expect(param.Value).To(Equal(outputPath))
+						}
+					}
+				}
+			})
+
+			It("should ensure resource replacements happen when needed", func() {
+				expectedResourceOrArg := corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				}
+				Expect(got.Spec.TaskSpec.Steps[0].Resources).To(Equal(expectedResourceOrArg))
+			})
+		})
+
+		Context("when the taskrun is generated by special settings", func() {
+			BeforeEach(func() {
+				build = &buildv1alpha1.Build{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      buildpacks,
 						Namespace: namespace,
@@ -271,10 +329,10 @@ func TestGenerateTaskRun(t *testing.T) {
 						},
 						StrategyRef: &buildv1alpha1.StrategyRef{
 							Name: buildpacks,
-							Kind: &clustertBuildStrategy,
+							Kind: &clusterBuildStrategy,
 						},
 						Dockerfile:   &dockerfile,
-						BuilderImage: &builderImage,
+						BuilderImage: builderImage,
 						Output: buildv1alpha1.Image{
 							ImageURL: outputPath,
 						},
@@ -285,8 +343,8 @@ func TestGenerateTaskRun(t *testing.T) {
 							},
 						},
 					},
-				},
-				buildRun: &buildv1alpha1.BuildRun{
+				}
+				buildRun = &buildv1alpha1.BuildRun{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      buildpacks + "-run",
 						Namespace: namespace,
@@ -309,12 +367,12 @@ func TestGenerateTaskRun(t *testing.T) {
 							Generate: false,
 						},
 					},
-				},
-				buildStrategy: &buildv1alpha1.BuildStrategy{
+				}
+				buildStrategy = &buildv1alpha1.BuildStrategy{
 					ObjectMeta: metav1.ObjectMeta{Name: buildpacks},
 					Spec: buildv1alpha1.BuildStrategySpec{
 						BuildSteps: []buildv1alpha1.BuildStep{
-							buildv1alpha1.BuildStep{
+							{
 								Container: corev1.Container{
 									Name:       "build",
 									Image:      "$(build.builder.image)",
@@ -332,79 +390,50 @@ func TestGenerateTaskRun(t *testing.T) {
 							},
 						},
 					},
-				},
-			},
-			&v1beta1.TaskRun{}, // not using it for now
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := generateTaskRun(tt.args.build, tt.args.buildRun, serviceAccountName, tt.args.buildStrategy.Spec.BuildSteps)
-			assert.True(t, reflect.DeepEqual(err, nil))
-			// ensure generated TaskRun's basic information are correct
-			assert.True(t, reflect.DeepEqual(true, strings.Contains(got.GenerateName, tt.args.buildRun.Name+"-")))
-			assert.True(t, reflect.DeepEqual(got.Namespace, namespace))
-			assert.True(t, reflect.DeepEqual(got.Spec.ServiceAccountName, buildpacks+"-serviceaccount"))
-			assert.True(t, reflect.DeepEqual(got.Labels[buildv1alpha1.LabelBuild], tt.args.build.Name))
-			assert.True(t, reflect.DeepEqual(got.Labels[buildv1alpha1.LabelBuildRun], tt.args.buildRun.Name))
+				}
+			})
 
-			// ensure generated TaskRun's input and output resources are correct
-			inputResources := got.Spec.Resources.Inputs
-			for _, inputResource := range inputResources {
-				if inputResource.Name == inputSourceResourceName {
-					assert.True(t, reflect.DeepEqual(inputResource.ResourceSpec.Type, v1beta1.PipelineResourceTypeGit))
-					params := inputResource.ResourceSpec.Params
-					for _, param := range params {
-						if param.Name == inputGitSourceURL {
-							assert.True(t, reflect.DeepEqual(param.Value, url))
-						}
-						if param.Name == inputGitSourceRevision {
-							assert.True(t, reflect.DeepEqual(param.Value, revision))
-						}
+			JustBeforeEach(func() {
+				got, err = buildrunCtl.GenerateTaskRun(build, buildRun, serviceAccountName, buildStrategy.Spec.BuildSteps)
+				Expect(err).To(BeNil())
+			})
+
+			It("should ensure generated TaskRun's basic information are correct", func() {
+				Expect(strings.Contains(got.GenerateName, buildRun.Name+"-")).To(Equal(true))
+				Expect(got.Namespace).To(Equal(namespace))
+				Expect(got.Spec.ServiceAccountName).To(Equal(buildpacks + "-serviceaccount"))
+				Expect(got.Labels[buildv1alpha1.LabelBuild]).To(Equal(build.Name))
+				Expect(got.Labels[buildv1alpha1.LabelBuildRun]).To(Equal(buildRun.Name))
+			})
+
+			It("should ensure generated TaskRun's spec special input params are correct", func() {
+				params := got.Spec.Params
+				for _, param := range params {
+					if param.Name == "BUILDER_IMAGE" {
+						Expect(param.Value.StringVal).To(Equal(builderImage.ImageURL))
 					}
-
-				}
-			}
-			outputResources := got.Spec.Resources.Inputs
-			for _, outputResource := range outputResources {
-				if outputResource.Name == outputImageResourceName {
-					assert.True(t, reflect.DeepEqual(outputResource.ResourceSpec.Type, v1beta1.PipelineResourceTypeImage))
-					params := outputResource.ResourceSpec.Params
-					for _, param := range params {
-						if param.Name == outputImageResourceURL {
-							assert.True(t, reflect.DeepEqual(param.Value, outputPath))
-						}
+					if param.Name == "DOCKERFILE" {
+						Expect(param.Value.StringVal).To(Equal(dockerfile))
 					}
+					if param.Name == "PATH_CONTEXT" {
+						Expect(param.Value.StringVal).To(Equal(contextDir))
+					}
+				}
+			})
 
+			It("should ensure resource replacements happen when needed", func() {
+				expectedResourceOrArg := corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
 				}
-			}
-
-			// ensure generated TaskRun's spec special input params are correct
-			params := got.Spec.Params
-			for _, param := range params {
-				if param.Name == inputParamBuilderImage {
-					assert.True(t, reflect.DeepEqual(param.Value.StringVal, builderImage.ImageURL))
-				}
-				if param.Name == inputParamDockerfile {
-					assert.True(t, reflect.DeepEqual(param.Value.StringVal, dockerfile))
-				}
-				if param.Name == inputParamPathContext {
-					assert.True(t, reflect.DeepEqual(param.Value.StringVal, contextDir))
-				}
-			}
-
-			expectedResourceOrArg := corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("500m"),
-					corev1.ResourceMemory: resource.MustParse("2Gi"),
-				},
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("500m"),
-					corev1.ResourceMemory: resource.MustParse("2Gi"),
-				},
-			}
-			// ensure resource replacements happen when needed
-			assert.True(t, reflect.DeepEqual(got.Spec.TaskSpec.Steps[0].Resources, expectedResourceOrArg))
+				Expect(got.Spec.TaskSpec.Steps[0].Resources).To(Equal(expectedResourceOrArg))
+			})
 		})
-	}
-}
+	})
+})


### PR DESCRIPTION
**Migrate the `generate_taskrun_test.go` to a ginkgo setup**
All test cases in `generate_taskrun_test.go` are rewritten into ginkgo.

 All unit-tests under pkg are passing:
```
build chinchen$ GO111MODULE=on ginkgo pkg/...
[1588802605] Controllers Suite - 0/0 specs  SUCCESS! 220.4µs PASS
[1588802605] Build Suite - 8/8 specs •••••••• SUCCESS! 271.768µs PASS
[1588802605] BuildRun Suite - 21/21 specs ••••••••••••••••••••• SUCCESS! 1.386822ms PASS
```