### PR TITLE
Report proper code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,4 @@ tags
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 # JetBrains IDE config
 .idea
-**/*.coverprofile*
+**/*coverprofile*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ install:
 script:
   - make
   # https://github.com/redhat-developer/build/issues/123
-  - make test
+  - make test-unit-coverage
   - make test-e2e TEST_IMAGE_REPO="$(./hack/install-registry.sh show):5000/redhat-developer/build-e2e"


### PR DESCRIPTION
Trying out a different solution for PR #177. Local output (ignore the long runtime, my machine is a little overwrought:

```sh
$ make test-unit
rm -rf build/coverage
mkdir build/coverage
GO111MODULE=on ginkgo \
        -randomizeAllSpecs \
        -randomizeSuites \
        -failOnPending \
        -nodes=4 \
        -compilers=2 \
        -slowSpecThreshold=240 \
        -race \
        -cover \
        -coverprofile=coverprofile \
        -outputdir=build/coverage \
        -trace \
        internal/... \
        pkg/...
[1588842940] BuildRun Suite - 10 specs - 4 nodes •••••••••• SUCCESS! 570.1907ms 
[1588842940] Build Suite - 8 specs - 4 nodes •••••••• SUCCESS! 885.5793ms 
[1588842940] ClusterBuildStrategy Suite - 1 specs - 4 nodes • SUCCESS! 106.3964ms 
[1588842940] BuildStrategy Suite - 1 specs - 4 nodes • SUCCESS! 139.0276ms 
[1588842940] Controllers Suite - 0 specs - 4 nodes  SUCCESS! 149.0164ms 
path is /mnt/c/Users/SaschaSchwarze/go/src/github.com/redhat-developer/build/build/coverage
All profiles combined

Ginkgo ran 5 suites in 1m35.2223817s
Test Suite Passed
gocov convert build/coverage/coverprofile > build/coverage/coverprofile.json
gocov report build/coverage/coverprofile.json

github.com/redhat-developer/build/pkg/controller/add_build.go                    init            100.00% (1/1)
github.com/redhat-developer/build/pkg/controller/add_buildrun.go                 init            100.00% (1/1)
github.com/redhat-developer/build/pkg/controller/add_buildstrategy.go            init            100.00% (1/1)
github.com/redhat-developer/build/pkg/controller/add_clusterbuildstrategy.go     init            100.00% (1/1)
github.com/redhat-developer/build/pkg/controller/controller.go                   AddToManager    0.00% (0/4)
github.com/redhat-developer/build/pkg/controller                                 ------------    50.00% (4/8)

github.com/redhat-developer/build/pkg/controller/build/build_controller.go       NewReconciler                                 100.00% (1/1)
github.com/redhat-developer/build/pkg/controller/build/build_controller.go       ReconcileBuild.validateStrategyRef            90.91% (10/11)
github.com/redhat-developer/build/pkg/controller/build/build_controller.go       ReconcileBuild.Reconcile                      85.71% (24/28)
github.com/redhat-developer/build/pkg/controller/build/build_controller.go       ReconcileBuild.validateClusterBuildStrategy   72.73% (8/11)
github.com/redhat-developer/build/pkg/controller/build/build_controller.go       ReconcileBuild.validateOutputSecret           72.73% (8/11)
github.com/redhat-developer/build/pkg/controller/build/build_controller.go       ReconcileBuild.validateBuildStrategy          72.73% (8/11)
github.com/redhat-developer/build/pkg/controller/build/build_controller.go       add                                           0.00% (0/8)
github.com/redhat-developer/build/pkg/controller/build/build_controller.go       @54:15                                        0.00% (0/1)
github.com/redhat-developer/build/pkg/controller/build/build_controller.go       Add                                           0.00% (0/1)
github.com/redhat-developer/build/pkg/controller/build/build_controller.go       @50:15                                        0.00% (0/1)
github.com/redhat-developer/build/pkg/controller/build                           -------------------------------------------   70.24% (59/84)

github.com/redhat-developer/build/pkg/controller/buildrun/credentials.go         ApplyCredentials                              100.00% (10/10)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go ReconcileBuildRun.updateBuildRunErrorStatus   100.00% (6/6)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go ReconcileBuildRun.retrieveBuildStrategy       100.00% (6/6)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go ReconcileBuildRun.retrieveClusterBuildStrategy
100.00% (6/6)
github.com/redhat-developer/build/pkg/controller/buildrun/generate_taskrun.go    getStringTransformations                      100.00% (4/4)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go NewReconciler                                 100.00% (1/1)
github.com/redhat-developer/build/pkg/controller/buildrun/generate_taskrun.go    generateTaskSpec                              96.67% (29/30)
github.com/redhat-developer/build/pkg/controller/buildrun/generate_taskrun.go    generateTaskRun                               93.75% (15/16)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go ReconcileBuildRun.retrieveTaskRun             88.89% (8/9)
github.com/redhat-developer/build/pkg/controller/buildrun/credentials.go         updateServiceAccountIfSecretNotLinked         75.00% (6/8)
github.com/redhat-developer/build/pkg/controller/buildrun/generate_taskrun.go    mergedResources                               71.43% (10/14)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go ReconcileBuildRun.Reconcile                   70.83% (51/72)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go ReconcileBuildRun.retrieveServiceAccount      39.39% (13/33)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go add                                           0.00% (0/8)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go isTaskRunRunning                              0.00% (0/3)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go @77:15                                        0.00% (0/1)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go @73:15                                        0.00% (0/1)
github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go Add                                           0.00% (0/1)
github.com/redhat-developer/build/pkg/controller/buildrun                        ----------------------------------------------
72.05% (165/229)

github.com/redhat-developer/build/pkg/controller/buildstrategy/buildstrategy_controller.go       ReconcileBuildStrategy.Reconcile
100.00% (3/3)
github.com/redhat-developer/build/pkg/controller/buildstrategy/buildstrategy_controller.go       NewReconciler
100.00% (1/1)
github.com/redhat-developer/build/pkg/controller/buildstrategy/buildstrategy_controller.go       add
0.00% (0/7)
github.com/redhat-developer/build/pkg/controller/buildstrategy/buildstrategy_controller.go       Add
0.00% (0/1)
github.com/redhat-developer/build/pkg/controller/buildstrategy                                   --------------------------------
33.33% (4/12)

github.com/redhat-developer/build/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go ReconcileClusterBuildStrategy.Reconcile 100.00% (3/3)
github.com/redhat-developer/build/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go NewReconciler
 100.00% (1/1)
github.com/redhat-developer/build/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go add
 0.00% (0/7)
github.com/redhat-developer/build/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go Add
 0.00% (0/1)
github.com/redhat-developer/build/pkg/controller/clusterbuildstrategy                                    --------------------------------------- 33.33% (4/12)

Total Coverage: 68.41% (236/345)
```