### PR TITLE
Make e2e tests configurable

### DIFF
--- a/HACK.md
+++ b/HACK.md
@@ -72,17 +72,23 @@ make test
 
 ## End-to-End Tests
 
-The following is a list of environment variables you can use when running e2e tests, this will override specific paths under the **Build** CRD [examples](samples/build).
+The following table contains a set of environment variables that control the behavior of the e2e tests.
+
+| Environment Variable            | Default                                                                         | Description                                                   |
+|---------------------------------|---------------------------------------------------------------------------------|---------------------------------------------------------------|
+| `TEST_NAMESPACE`                | `default`                                                                       | Target namespace to execute tests upon, default is `default`. |
+| `TEST_E2E_FLAGS`                | `-failFast -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=15m -trace -v` | Ginkgo flags. See all Ginkgo flags here: [The Ginkgo CLI](https://onsi.github.io/ginkgo/#the-ginkgo-cli). Especially of interest are `--focus` and `--skip` to run selective tests. |
+| `TEST_E2E_CREATE_GLOBALOBJECTS` | `true`                                                                          | Boolean, if `false`, the custom resource definitions and (cluster) build strategies are not created and deleted by the e2e test code |
+| `TEST_E2E_OPERATOR`             | `start_local`                                                                   | String with allowed values `start_local` (will start the local operator and print its logs add the end of the test run) and `managed_outside` (will assume that the operator is running through whatever means) |
+| `TEST_E2E_VERIFY_TEKTONOBJECTS` | `true`                                                                          | Boolean, if false, the verification code will not try to verify the TaskRun object status |
+
+The following table contains a list of environment variables you that will override specific paths under the **Build** CRD.
 
 | Environment Variable               | Path                           | Description                                                   |
 |------------------------------------|--------------------------------|---------------------------------------------------------------|
-| `TEST_NAMESPACE`                   | _none_                         | Target namespace to execute tests upon, default is `default`. |
 | `TEST_IMAGE_REPO`                  | `spec.output.image`            | Image repository for end-to-end tests                         |
 | `TEST_IMAGE_REPO_SECRET`           | `spec.output.credentials.name` | Container credentials secret name                             |
 | `TEST_IMAGE_REPO_DOCKERCONFIGJSON` | _none_                         | JSON payload equivalent to `~/.docker/config.json`            |
-| `TEST_E2E_FLAGS`                   | _none_                         | Ginkgo flags.                                                 |
-
-The default for `TEST_E2E_FLAGS` is `-failFast -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=15m -trace -v`. See all Ginkgo flags here: [The Ginkgo CLI](https://onsi.github.io/ginkgo/#the-ginkgo-cli). Especially of interest are `--focus` and `--skip` to run selective tests.
 
 The contents of `TEST_IMAGE_REPO_DOCKERCONFIGJSON` can be obtained from [quay.io](quay.io) using a [robot account](https://docs.quay.io/glossary/robot-accounts.html). The JSON payload is for example:
 
@@ -90,7 +96,13 @@ The contents of `TEST_IMAGE_REPO_DOCKERCONFIGJSON` can be obtained from [quay.io
 { "auths": { "quay.io": { "auth": "<secret-credentials>" } } }
 ```
 
-When both `TEST_IMAGE_REPO_SECRET` and `TEST_IMAGE_REPO_DOCKERCONFIGJSON` are informed, a new secret is created for end-to-end tests, named by  `TEST_IMAGE_REPO_SECRET`. However, when `TEST_IMAGE_REPO_DOCKERCONFIGJSON` is empty, e2e tests are expecting to find a pre-existing one.
+When both `TEST_IMAGE_REPO_SECRET` and `TEST_IMAGE_REPO_DOCKERCONFIGJSON` are informed, a new secret is created for end-to-end tests, named by `TEST_IMAGE_REPO_SECRET`. However, when `TEST_IMAGE_REPO_DOCKERCONFIGJSON` is empty, e2e tests are expecting to find a pre-existing one.
+
+The following table contains a list of environment variables that will override specific paths under the **BuildRun** CRD.
+
+| Environment Variable          | Path                   | Description |
+|--------------------------------|-----------------------|-------------|
+| `TEST_E2E_SERVICEACCOUNT_NAME` | `spec.serviceAccount` | The name of the service account used by the build runs, the code will try to create the service account but not fail if it already exists. Special value is `generated`, which will lead to using the auto-generation feature for each build run. |
 
 To execute the end-to-end tests, run:
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -58,9 +58,17 @@ func TestBuildRun(t *testing.T) {
 var _ = SynchronizedBeforeSuite(func() []byte {
 	var err error
 
-	Logf("Starting local operator")
-	operatorCmd, err = startLocalOperator()
-	Expect(err).ToNot(HaveOccurred(), "Failed to start local operator")
+	operator := os.Getenv(EnvVarOperator)
+	switch operator {
+	case "start_local":
+		Logf("Starting local operator")
+		operatorCmd, err = startLocalOperator()
+		Expect(err).ToNot(HaveOccurred(), "Failed to start local operator")
+	case "managed_outside":
+		Logf("Using operator that is started outside of the e2e test suite.")
+	default:
+		Fail("Unexpected value for " + EnvVarOperator + ": '" + operator + "'")
+	}
 
 	// add schemes to operator-sdk test framework
 	Logf("Adding schemes to operator-sdk test framework")
@@ -81,19 +89,24 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).ToNot(HaveOccurred(), "unable to obtain namespace")
 	Logf("Namespace is %s", namespace)
 
-	// wait for operator deployment
-	Logf("Waiting for operator deployment")
 	f := framework.Global
-	err = e2eutil.WaitForOperatorDeployment(
-		testingT,
-		f.KubeClient,
-		namespace,
-		"build-operator",
-		1,
-		operatorDeploymentRetryInterval,
-		operatorDeploymentTimeout,
-	)
-	Expect(err).ToNot(HaveOccurred(), "error on waiting for operator deployment")
+
+	if operator != "managed_outside" {
+		// wait for operator deployment
+		Logf("Waiting for operator deployment")
+		err = e2eutil.WaitForOperatorDeployment(
+			testingT,
+			f.KubeClient,
+			// TODO we currently have no codepath where this is relevant, but this namespace is the wrong one
+			// it is the watch namespace, but needs to be the operator namespace
+			namespace,
+			"build-operator",
+			1,
+			operatorDeploymentRetryInterval,
+			operatorDeploymentTimeout,
+		)
+		Expect(err).ToNot(HaveOccurred(), "error on waiting for operator deployment")
+	}
 
 	// create the pipeline service account
 	Logf("Creating the pipeline service account")
@@ -103,25 +116,29 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Logf("Creating the container registry secret")
 	createContainerRegistrySecret(globalCtx, f, namespace)
 
-	// create cluster build strategies
-	Logf("Creating cluster build strategies")
-	for _, clusterBuildStrategy := range clusterBuildStrategies {
-		Logf("Creating cluster build strategy %s", clusterBuildStrategy)
-		cbs, err := clusterBuildStrategyTestData(clusterBuildStrategy)
-		Expect(err).ToNot(HaveOccurred())
-		cbs.SetNamespace(namespace)
+	if os.Getenv(EnvVarCreateGlobalObjects) == "true" {
+		// create cluster build strategies
+		Logf("Creating cluster build strategies")
+		for _, clusterBuildStrategy := range clusterBuildStrategies {
+			Logf("Creating cluster build strategy %s", clusterBuildStrategy)
+			cbs, err := clusterBuildStrategyTestData(clusterBuildStrategy)
+			Expect(err).ToNot(HaveOccurred())
+			cbs.SetNamespace(namespace)
 
-		createClusterBuildStrategy(globalCtx, f, cbs)
-	}
+			createClusterBuildStrategy(globalCtx, f, cbs)
+		}
 
-	// create namespace build strategies
-	Logf("Creating namespace build strategies")
-	for _, namespaceBuildStrategy := range namespaceBuildStrategies {
-		Logf("Creating namespace build strategy %s", namespaceBuildStrategy)
-		nbs, err := buildStrategyTestData(namespace, namespaceBuildStrategy)
-		Expect(err).ToNot(HaveOccurred())
+		// create namespace build strategies
+		Logf("Creating namespace build strategies")
+		for _, namespaceBuildStrategy := range namespaceBuildStrategies {
+			Logf("Creating namespace build strategy %s", namespaceBuildStrategy)
+			nbs, err := buildStrategyTestData(namespace, namespaceBuildStrategy)
+			Expect(err).ToNot(HaveOccurred())
 
-		createNamespacedBuildStrategy(globalCtx, f, nbs)
+			createNamespacedBuildStrategy(globalCtx, f, nbs)
+		}
+	} else {
+		Logf("Build strategy creation skipped.")
 	}
 
 	return nil

--- a/test/e2e/validators.go
+++ b/test/e2e/validators.go
@@ -28,6 +28,10 @@ import (
 )
 
 const (
+	EnvVarCreateGlobalObjects  = "TEST_E2E_CREATE_GLOBALOBJECTS"
+	EnvVarOperator             = "TEST_E2E_OPERATOR"
+	EnvVarServiceAccountName   = "TEST_E2E_SERVICEACCOUNT_NAME"
+	EnvVarVerifyTektonObjects  = "TEST_E2E_VERIFY_TEKTONOBJECTS"
 	EnvVarImageRepo            = "TEST_IMAGE_REPO"
 	EnvVarEnablePrivateRepos   = "TEST_PRIVATE_REPO"
 	EnvVarImageRepoSecret      = "TEST_IMAGE_REPO_SECRET"
@@ -36,8 +40,6 @@ const (
 	EnvVarSourceURLGitlab      = "TEST_PRIVATE_GITLAB"
 	EnvVarSourceURLSecret      = "TEST_SOURCE_SECRET"
 )
-
-const TestServiceAccountName = "pipeline"
 
 // cleanupOptions return a CleanupOptions instance.
 func cleanupOptions(ctx *framework.TestCtx) *framework.CleanupOptions {
@@ -48,18 +50,25 @@ func cleanupOptions(ctx *framework.TestCtx) *framework.CleanupOptions {
 	}
 }
 
-// createPipelineServiceAccount make sure the "pipeline" SA is created, or already exists.
+// createPipelineServiceAccount reads the TEST_E2E_SERVICEACCOUNT_NAME environment variable. If the value is "generated", then nothing is done.
+// Otherwise it will create the service account. No error occurs if the service account already exists.
 func createPipelineServiceAccount(ctx *framework.TestCtx, f *framework.Framework, namespace string) {
-	serviceAccount := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      TestServiceAccountName,
-		},
-	}
-	Logf("Creating '%s' service-account", TestServiceAccountName)
-	err := f.Client.Create(goctx.TODO(), serviceAccount, cleanupOptions(ctx))
-	if err != nil && !k8serrors.IsAlreadyExists(err) {
-		Expect(err).ToNot(HaveOccurred(), "Error creating service account")
+	serviceAccountName := os.Getenv(EnvVarServiceAccountName)
+
+	if serviceAccountName == "generated" {
+		Logf("Skipping creation of service account, generated one will be used per build run.")
+	} else {
+		serviceAccount := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      serviceAccountName,
+			},
+		}
+		Logf("Creating '%s' service-account", serviceAccountName)
+		err := f.Client.Create(goctx.TODO(), serviceAccount, cleanupOptions(ctx))
+		if err != nil && !k8serrors.IsAlreadyExists(err) {
+			Expect(err).ToNot(HaveOccurred(), "Error creating service account")
+		}
 	}
 }
 
@@ -138,22 +147,26 @@ func validateController(
 	Expect(err).ToNot(HaveOccurred(), "Failed to create build run.")
 
 	// Ensure that a TaskRun has been created and is in pending or running state
-	Eventually(func() string {
-		taskRun, err := getTaskRun(f, testBuildRun)
-		if err != nil {
-			Logf("Retrieving TaskRun error: '%s'", err)
-			return ""
-		}
-		if taskRun == nil {
-			Logf("TaskRun is not yet generated!")
-			return ""
-		}
-		if len(taskRun.Status.Conditions) == 0 {
-			Logf("TaskRun has not yet conditions.")
-			return ""
-		}
-		return taskRun.Status.Conditions[0].Reason
-	}, 300*time.Second, 5*time.Second).Should(BeElementOf(pendingAndRunningStatues), "TaskRun not pending or running")
+	if os.Getenv(EnvVarVerifyTektonObjects) == "true" {
+		Eventually(func() string {
+			taskRun, err := getTaskRun(f, testBuildRun)
+			if err != nil {
+				Logf("Retrieving TaskRun error: '%s'", err)
+				return ""
+			}
+			if taskRun == nil {
+				Logf("TaskRun is not yet generated!")
+				return ""
+			}
+			if len(taskRun.Status.Conditions) == 0 {
+				Logf("TaskRun has not yet conditions.")
+				return ""
+			}
+			return taskRun.Status.Conditions[0].Reason
+		}, 300*time.Second, 5*time.Second).Should(BeElementOf(pendingAndRunningStatues), "TaskRun not pending or running")
+	} else {
+		Logf("TaskRun verification skipped.")
+	}
 
 	// Ensure BuildRun is in pending or running state
 	buildRunNsName := types.NamespacedName{Name: testBuildRun.Name, Namespace: namespace}
@@ -255,6 +268,19 @@ func buildRunTestData(ns string, identifier string, buildRunCRPath string) (*ope
 	buildRun.SetNamespace(ns)
 	buildRun.SetName(identifier)
 	buildRun.Spec.BuildRef.Name = identifier
+
+	serviceAccountName := os.Getenv(EnvVarServiceAccountName)
+
+	if serviceAccountName == "generated" {
+		buildRun.Spec.ServiceAccount = &buildv1alpha1.ServiceAccount{
+			Generate: true,
+		}
+	} else {
+		buildRun.Spec.ServiceAccount = &buildv1alpha1.ServiceAccount{
+			Name: &serviceAccountName,
+		}
+	}
+
 	return buildRun, err
 }
 


### PR DESCRIPTION
Resolves https://github.com/redhat-developer/build/issues/194

I introduced a set of environment variables that are explained in the HACK.MD modification as well as in the above mentioned issue. The changes allow to run the e2e tests in an environment where the operator is already running, build strategies are already configured and where Tekton objects are not accessible for the user.