### PR TITLE
Updates Makefile to fix make local target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOARCH ?= amd64
 GO_FLAGS ?= -v -mod=vendor
 
 # configure zap based logr
-OPERATOR_FLAGS ?= --zap-level=1 --zap-level=debug --zap-encoder=console
+ZAP_FLAGS ?= --zap-level=1 --zap-level=debug --zap-encoder=console
 # extra flags passed to operator-sdk
 OPERATOR_SDK_EXTRA_ARGS ?= --debug
 
@@ -102,7 +102,7 @@ crds:
 	@hack/crd.sh install
 
 local: crds build
-	operator-sdk run --local --operator-flags="$(ZAP_ENCODER_FLAG)" $(OPERATOR_SDK_EXTRA_ARGS)
+	operator-sdk run --local --operator-flags="$(ZAP_FLAGS)"
 
 clean:
 	rm -rf $(OUTPUT_DIR)


### PR DESCRIPTION
fixes issue #198 

## Output

```
➜  build git:(fix-make-local) ✗ make local
hack/crd.sh uninstall
clusterrole.rbac.authorization.k8s.io "build-operator" deleted
clusterrolebinding.rbac.authorization.k8s.io "build-operator" deleted
serviceaccount "build-operator" deleted
deployment.apps "build-operator" deleted
customresourcedefinition.apiextensions.k8s.io "buildstrategies.build.dev" deleted
customresourcedefinition.apiextensions.k8s.io "clusterbuildstrategies.build.dev" deleted
customresourcedefinition.apiextensions.k8s.io "builds.build.dev" deleted
customresourcedefinition.apiextensions.k8s.io "buildruns.build.dev" deleted
Error from server (NotFound): error when deleting "samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml": the server could not find the requested resource (delete clusterbuildstrategies.build.dev buildpacks-v3)
[WARN] Unable to delete resource 'samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml'
Error from server (NotFound): error when deleting "samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml": the server could not find the requested resource (delete clusterbuildstrategies.build.dev buildah)
[WARN] Unable to delete resource 'samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml'
Error from server (NotFound): error when deleting "samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml": the server could not find the requested resource (delete clusterbuildstrategies.build.dev kaniko)
[WARN] Unable to delete resource 'samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml'
Error from server (NotFound): error when deleting "samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml": the server could not find the requested resource (delete clusterbuildstrategies.build.dev source-to-image)
[WARN] Unable to delete resource 'samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml'
Error from server (NotFound): error when deleting "samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml": the server could not find the requested resource (delete clusterbuildstrategies.build.dev source-to-image-redhat)
[WARN] Unable to delete resource 'samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml'
clusterrole.rbac.authorization.k8s.io/build-operator created
clusterrolebinding.rbac.authorization.k8s.io/build-operator created
serviceaccount/build-operator created
deployment.apps/build-operator created
customresourcedefinition.apiextensions.k8s.io/buildstrategies.build.dev created
customresourcedefinition.apiextensions.k8s.io/clusterbuildstrategies.build.dev created
customresourcedefinition.apiextensions.k8s.io/builds.build.dev created
customresourcedefinition.apiextensions.k8s.io/buildruns.build.dev created
clusterbuildstrategy.build.dev/buildpacks-v3 created
clusterbuildstrategy.build.dev/buildah created
clusterbuildstrategy.build.dev/kaniko created
clusterbuildstrategy.build.dev/source-to-image created
clusterbuildstrategy.build.dev/source-to-image-redhat created
go mod vendor
go build -v -mod=vendor -o build/_output/bin/build-operator cmd/manager/main.go
operator-sdk run --local --operator-flags="--zap-level=1 --zap-level=debug --zap-encoder=console"
INFO[0000] Running the operator locally in namespace sbo-try-1. 
2020-05-14T03:51:51.124+0530	INFO	cmd	Operator Version: 0.0.1
2020-05-14T03:51:51.124+0530	INFO	cmd	Go Version: go1.14.2
2020-05-14T03:51:51.124+0530	INFO	cmd	Go OS/Arch: linux/amd64
2020-05-14T03:51:51.124+0530	INFO	cmd	Version of operator-sdk: v0.17.0
2020-05-14T03:51:51.126+0530	INFO	leader	Trying to become the leader.
2020-05-14T03:51:51.126+0530	INFO	leader	Skipping leader election; not running in a cluster.
2020-05-14T03:51:53.480+0530	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": "0.0.0.0:8383"}
2020-05-14T03:51:53.481+0530	INFO	cmd	Registering Components.
2020-05-14T03:51:53.482+0530	DEBUG	kubemetrics	Starting collecting operator types
2020-05-14T03:51:53.482+0530	DEBUG	kubemetrics	Generating metric families	{"apiVersion": "build.dev/v1alpha1", "kind": "BuildRun"}
2020-05-14T03:51:55.833+0530	DEBUG	kubemetrics	Generating metric families	{"apiVersion": "build.dev/v1alpha1", "kind": "Build"}
2020-05-14T03:51:58.196+0530	DEBUG	kubemetrics	Generating metric families	{"apiVersion": "build.dev/v1alpha1", "kind": "BuildStrategy"}
2020-05-14T03:52:00.548+0530	DEBUG	kubemetrics	Generating metric families	{"apiVersion": "build.dev/v1alpha1", "kind": "ClusterBuildStrategy"}

```