### PR TITLE
Add BuildRun deletion when delete the Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ TEKTON_VERSION ?= v0.11.3
 SDK_VERSION ?= v0.17.0
 
 # E2E test flags
-TEST_E2E_FLAGS ?= -failFast -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=15m -trace -v
+TEST_E2E_FLAGS ?= -failFast -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=20m -trace -v
 
 # E2E test operator behavior, can be start_local or managed_outside
 TEST_E2E_OPERATOR ?= start_local

--- a/docs/build.md
+++ b/docs/build.md
@@ -52,7 +52,7 @@ The `Build` definition supports the following fields:
   - `spec.parameters` - Refers to a list of `name-value` that could be used to loosely type parameters in the `BuildStrategy`.
   - `spec.dockerfile` - Path to a Dockerfile to be used for building an image. (_Use this path for strategies that require a Dockerfile_)
   - `spec.timeout` - Defines a custom timeout. The value needs to be parsable by [ParseDuration](https://golang.org/pkg/time/#ParseDuration), for example `5m`. The default is ten minutes. The value can be overwritten in the `BuildRun`.
-  - `metadata.annotations[build.build.dev/buildRunDeletion]` - Defines if delete all related BuildRuns when deleting the Build
+  - `metadata.annotations[build.build.dev/build-run-deletion]` - Defines if delete all related BuildRuns when deleting the Build. The default is `false`.
 
 ### Defining the Source
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -8,6 +8,7 @@
   - [Defining the Builder or Dockerfile](#defining-the-builder-or-dockerfile)
   - [Defining Resources](#defining-resources)
   - [Defining the Output](#defining-the-output)
+- [Using Finalizers](#using-finalizers)
 
 ## Overview
 
@@ -224,4 +225,18 @@ spec:
     image: us.icr.io/source-to-image-build/nodejs-ex
     credentials:
       name: icr-knbuild
+```
+
+## Using Finalizers
+
+The Build controller support Kubernetes finalizers in order to asynchronously delete resources. For the case of a Build instance with a particular annotation,
+related `BuildRuns` will be deleted prior to deleting the `Build` instance. The flow is very simple, if you want to garbage collect BuildRuns then the `build.build.dev/build-run-deletion` annotation needs to be set to `true` in the `Build` definition, if this behaviour is not desired, then the annotation needs to be set to `false`. By default the annotation is never present in a `Build` definition. See an example of how to define this annotation:
+
+```yaml
+apiVersion: build.dev/v1alpha1
+kind: Build
+metadata:
+  name: kaniko-golang-build
+  annotations:
+    build.build.dev/build-run-deletion: "true"
 ```

--- a/docs/build.md
+++ b/docs/build.md
@@ -52,6 +52,7 @@ The `Build` definition supports the following fields:
   - `spec.parameters` - Refers to a list of `name-value` that could be used to loosely type parameters in the `BuildStrategy`.
   - `spec.dockerfile` - Path to a Dockerfile to be used for building an image. (_Use this path for strategies that require a Dockerfile_)
   - `spec.timeout` - Defines a custom timeout. The value needs to be parsable by [ParseDuration](https://golang.org/pkg/time/#ParseDuration), for example `5m`. The default is ten minutes. The value can be overwritten in the `BuildRun`.
+  - `metadata.annotations[build.build.dev/buildRunDeletion]` - Defines if delete all related BuildRuns when deleting the Build
 
 ### Defining the Source
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/redhat-developer/build
 go 1.13
 
 require (
+	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.4
 	github.com/gobuffalo/envy v1.7.1 // indirect
 	github.com/golang/protobuf v1.4.0 // indirect

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -8,7 +8,7 @@ import (
 var (
 	LabelBuild                 = "build.build.dev/name"
 	LabelBuildGeneration       = "build.build.dev/generation"
-	AnnotationBuildRunDeletion = "build.build.dev/buildRunDeletion"
+	AnnotationBuildRunDeletion = "build.build.dev/build-run-deletion"
 	BuildFinalizer             = "finalizer.build.build.dev"
 )
 

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -6,8 +6,10 @@ import (
 )
 
 var (
-	LabelBuild           = "build.build.dev/name"
-	LabelBuildGeneration = "build.build.dev/generation"
+	LabelBuild                 = "build.build.dev/name"
+	LabelBuildGeneration       = "build.build.dev/generation"
+	AnnotationBuildRunDeletion = "build.build.dev/buildRunDeletion"
+	BuildFinalizer             = "finalizer.build.build.dev"
 )
 
 // BuildSpec defines the desired state of Build

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -116,10 +116,10 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 		return reconcile.Result{}, fmt.Errorf("errors: %v %v", err, updateErr)
 	}
 
-	if buildRun.Labels == nil {
+	if buildRun.GetLabels() == nil {
 		buildRun.Labels = make(map[string]string)
 	}
-	if buildRun.Labels[buildv1alpha1.LabelBuild] == "" {
+	if buildRun.GetLabels()[buildv1alpha1.LabelBuild] == "" {
 		buildRun.Labels[buildv1alpha1.LabelBuild] = build.Name
 		buildRun.Labels[buildv1alpha1.LabelBuildGeneration] = strconv.FormatInt(build.Generation, 10)
 		err = r.client.Update(context.TODO(), buildRun)
@@ -156,7 +156,6 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -132,6 +132,11 @@ var _ = Describe("Reconcile BuildRun", func() {
 				)
 				statusWriter.UpdateCalls(statusCall)
 
+				// Stub that asserts the BuildRun label fields when
+				// Label updates for a BuildRun take place
+				labelCall := ctl.StubBuildRunLabel(buildSample)
+				statusWriter.UpdateCalls(labelCall)
+
 				// Assert for none errors while we exit the Reconcile
 				// after updating the BuildRun status with the existing
 				// TaskRun one
@@ -166,6 +171,11 @@ var _ = Describe("Reconcile BuildRun", func() {
 					buildSample,
 				)
 				statusWriter.UpdateCalls(statusCall)
+
+				// Stub that asserts the BuildRun label fields when
+				// Label updates for a BuildRun take place
+				labelCall := ctl.StubBuildRunLabel(buildSample)
+				statusWriter.UpdateCalls(labelCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())

--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					"Succeeded",
 					&taskRunName,
 					corev1.ConditionTrue,
-					buildSample,
+					buildSample.Spec,
 				)
 				statusWriter.UpdateCalls(statusCall)
 
@@ -168,7 +168,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					fmt.Sprintf(" \"%s\" not found", saName),
 					emptyTaskRunName,
 					corev1.ConditionFalse,
-					buildSample,
+					buildSample.Spec,
 				)
 				statusWriter.UpdateCalls(statusCall)
 

--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					"Succeeded",
 					&taskRunName,
 					corev1.ConditionTrue,
-					buildSample.Spec,
+					buildSample,
 				)
 				statusWriter.UpdateCalls(statusCall)
 
@@ -163,7 +163,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					fmt.Sprintf(" \"%s\" not found", saName),
 					emptyTaskRunName,
 					corev1.ConditionFalse,
-					buildSample.Spec,
+					buildSample,
 				)
 				statusWriter.UpdateCalls(statusCall)
 

--- a/samples/build/build_buildpacks-v3_cr.yaml
+++ b/samples/build/build_buildpacks-v3_cr.yaml
@@ -4,7 +4,7 @@ kind: Build
 metadata:
   name: buildpack-nodejs-build
   annotations:
-    build.build.dev/buildRunDeletion: "true"
+    build.build.dev/build-run-deletion: "false"
 spec:
   source:
     url: https://github.com/sclorg/nodejs-ex

--- a/samples/build/build_buildpacks-v3_cr.yaml
+++ b/samples/build/build_buildpacks-v3_cr.yaml
@@ -3,6 +3,8 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-build
+  annotations:
+    build.build.dev/buildRunDeletion: "true"
 spec:
   source:
     url: https://github.com/sclorg/nodejs-ex

--- a/samples/build/build_kaniko_cr.yaml
+++ b/samples/build/build_kaniko_cr.yaml
@@ -3,6 +3,8 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 metadata:
   name: kaniko-golang-build
+  annotations:
+    build.build.dev/build-run-deletion: "true"
 spec:
   source:
     url: https://github.com/sbose78/taxi

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -196,6 +196,16 @@ func (c *Catalog) StubBuildRunStatus(reason string, name *string, status corev1.
 			if object.Status.BuildSpec != nil {
 				Expect(*object.Status.BuildSpec).To(Equal(buildSample.Spec))
 			}
+		}
+		return nil
+	}
+}
+
+// StubBuildRunLabel asserts Label fields on a BuildRun resource
+func (c *Catalog) StubBuildRunLabel(buildSample *build.Build) func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
+	return func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
+		switch object := object.(type) {
+		case *build.BuildRun:
 			Expect(object.Labels[build.LabelBuild]).To(Equal(buildSample.Name))
 			Expect(object.Labels[build.LabelBuildGeneration]).To(Equal(strconv.FormatInt(buildSample.Generation, 10)))
 		}

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -29,7 +29,6 @@ func (c *Catalog) BuildWithClusterBuildStrategy(name string, ns string, strategy
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
-			Annotations: map[string]string{build.AnnotationBuildRunDeletion: "true"},
 		},
 		Spec: build.BuildSpec{
 			Source: build.GitSource{
@@ -194,7 +193,7 @@ func (c *Catalog) StubBuildRunStatus(reason string, name *string, status corev1.
 			Expect(object.Status.Succeeded).To(Equal(status))
 			Expect(object.Status.LatestTaskRunRef).To(Equal(name))
 			if object.Status.BuildSpec != nil {
-				Expect(*object.Status.BuildSpec).To(Equal(buildSample.Spec))
+				Expect(*object.Status.BuildSpec).To(Equal(buildSpec))
 			}
 		}
 		return nil

--- a/test/data/build_kaniko_cr_advanced_dockerfile.yaml
+++ b/test/data/build_kaniko_cr_advanced_dockerfile.yaml
@@ -3,6 +3,8 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 metadata:
   name: kaniko-advanced-dockerfile
+  annotations:
+    build.build.dev/buildRunDeletion: "false"
 spec:
   source:
     url: https://github.com/SaschaSchwarze0/java-simple

--- a/test/data/build_kaniko_cr_advanced_dockerfile.yaml
+++ b/test/data/build_kaniko_cr_advanced_dockerfile.yaml
@@ -4,7 +4,7 @@ kind: Build
 metadata:
   name: kaniko-advanced-dockerfile
   annotations:
-    build.build.dev/buildRunDeletion: "false"
+    build.build.dev/build-run-deletion: "false"
 spec:
   source:
     url: https://github.com/SaschaSchwarze0/java-simple

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -46,6 +46,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
+			validateBuildDeletion(namespace, "buildah-custom-context-dockerfile", br, false)
 		})
 	})
 
@@ -76,6 +77,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
+			validateBuildDeletion(namespace, "buildpacks-v3", br, false)
 		})
 	})
 
@@ -141,6 +143,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
+			validateBuildDeletion(namespace, "kaniko", br, true)
 		})
 	})
 


### PR DESCRIPTION
- Add new `metadata.annotations[build.build.dev/buildRunDeletion]` 
- Add annotation check in Build Update check
- Add an ew finalizer in Build
- Remove the related BuildRun when deleting the Build
- Add test to verify the logic in build controller ut
- Add deletion verification in e2e tests

This PR is for the feature: https://github.com/redhat-developer/build/issues/94