### PR TITLE
BUG: Fix the errors with heroku

### DIFF
--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -71,7 +71,6 @@ spec:
         - -layers=/layers
         - -cache-dir=/cache
         - -group=/layers/group.toml
-        - -helpers=true
         - $(build.output.image)
       volumeMounts:
         - name: cache-dir

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -71,7 +71,6 @@ spec:
         - -layers=/layers
         - -cache-dir=/cache
         - -group=/layers/group.toml
-        - -helpers=true
         - $(build.output.image)
       volumeMounts:
         - name: cache-dir


### PR DESCRIPTION
While I was running the e2e tests, `heroku` failed for because of the undefined `--helpers` flag:
```
~ chinchen$ kubectl -n default logs buildpacks-v3-heroku-btc92-pod-w5gwc -c step-step-export
flag provided but not defined: -helpers
```
The flag probably was removed on the newer version of heroku image.
https://hub.docker.com/r/heroku/buildpacks/tags

Therefore, I removed the `--helpers` flag in yaml files respectively.
