### PR TITLE
Add basic custom metrics support

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,9 +22,11 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
+	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/redhat-developer/build/pkg/apis"
 	"github.com/redhat-developer/build/pkg/controller"
+	buildMetrics "github.com/redhat-developer/build/pkg/metrics"
 	"github.com/redhat-developer/build/version"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
@@ -32,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-	"github.com/operator-framework/operator-sdk/pkg/ready"
 
 	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
@@ -145,6 +146,7 @@ func main() {
 
 	// Add the Metrics Service
 	addMetrics(ctx, cfg, namespace)
+	buildMetrics.InitPrometheus(c)
 
 	ctxlog.Info(ctx, "Starting the Cmd.")
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,12 @@
+# Build Controller Metrics
+
+The Build component exposes several metrics to help you monitor the health and behavior of your build resources.
+
+Following build metrics are exposed at service `build-operator-metrics` on port `8383`.
+
+| Name | Type | Description | Label | Status |
+| ---- | ---- | ----------- | ----- | ------ |
+| `build_builds_registered_total` | Counter | Number of total registered Builds. | buildstrategy=<build_buildstrategy_name> | experimental |
+| `build_buildruns_completed_total` | Counter | Number of total completed BuildRuns. | buildstrategy=<build_buildstrategy_name> | experimental |
+| `build_buildrun_establish_duration_seconds` | Histogram | BuildRun establish duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
+| `build_buildrun_completion_duration_seconds` | Histogram | BuildRun completion duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/gomega v1.9.0
 	github.com/operator-framework/operator-sdk v0.17.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.5.1
 	github.com/spf13/pflag v1.0.5
 	github.com/tektoncd/pipeline v0.11.3
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect

--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -3,16 +3,17 @@ package build
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/pkg/errors"
 	build "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
 	"github.com/redhat-developer/build/pkg/config"
 	"github.com/redhat-developer/build/pkg/ctxlog"
+	buildmetrics "github.com/redhat-developer/build/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -164,6 +165,9 @@ func (r *ReconcileBuild) Reconcile(request reconcile.Request) (reconcile.Result,
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+
+	// Increase Build count in metrics
+	buildmetrics.BuildCountInc(b.Spec.StrategyRef.Name)
 
 	ctxlog.Debug(ctx, "finishing reconciling Build", namespace, request.Namespace, name, request.Name)
 	return reconcile.Result{}, nil

--- a/pkg/controller/build/build_controller_test.go
+++ b/pkg/controller/build/build_controller_test.go
@@ -291,6 +291,20 @@ var _ = Describe("Reconcile Build", func() {
 			})
 
 			It("sets a finalizer if annotation equals true", func() {
+				// Fake some client LIST calls and ensure we populate all
+				// different resources we could get during reconciliation
+				client.ListCalls(func(context context.Context, object runtime.Object, _ ...crc.ListOption) error {
+					switch object := object.(type) {
+					case *corev1.SecretList:
+						list := ctl.SecretList(registrySecret)
+						list.DeepCopyInto(object)
+					case *build.ClusterBuildStrategyList:
+						list := ctl.ClusterBuildStrategyList(buildStrategyName)
+						list.DeepCopyInto(object)
+					}
+					return nil
+				})
+
 				// override Build definition with one annotation
 				annotationFinalizer[build.AnnotationBuildRunDeletion] = "true"
 				buildSample = ctl.BuildWithCustomAnnotationAndFinalizer(
@@ -310,6 +324,20 @@ var _ = Describe("Reconcile Build", func() {
 			})
 
 			It("removes a finalizer if annotation equals false and finalizer exists", func() {
+				// Fake some client LIST calls and ensure we populate all
+				// different resources we could get during reconciliation
+				client.ListCalls(func(context context.Context, object runtime.Object, _ ...crc.ListOption) error {
+					switch object := object.(type) {
+					case *corev1.SecretList:
+						list := ctl.SecretList(registrySecret)
+						list.DeepCopyInto(object)
+					case *build.ClusterBuildStrategyList:
+						list := ctl.ClusterBuildStrategyList(buildStrategyName)
+						list.DeepCopyInto(object)
+					}
+					return nil
+				})
+
 				// override Build definition with one annotation
 				annotationFinalizer[build.AnnotationBuildRunDeletion] = "false"
 				buildSample = ctl.BuildWithCustomAnnotationAndFinalizer(

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,76 @@
+package metrics
+
+import (
+	"github.com/redhat-developer/build/pkg/config"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	buildStrategyLabel string = "buildstrategy"
+	namespaceLabel string = "namespace"
+)
+
+var (
+	buildCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "build_builds_registered_total",
+			Help: "Number of total registered Builds.",
+		},
+		[]string{buildStrategyLabel})
+
+	buildRunCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "build_buildruns_completed_total",
+			Help: "Number of total completed BuildRuns.",
+		},
+		[]string{buildStrategyLabel})
+
+	buildRunEstablishDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "build_buildrun_establish_duration_seconds",
+			Help: "BuildRun establish duration in seconds.",
+			Buckets: prometheus.LinearBuckets(0, 0.5, 10),
+		},
+		[]string{buildStrategyLabel, namespaceLabel})
+
+	buildRunCompletionDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "build_buildrun_completion_duration_seconds",
+			Help:    "BuildRun completion duration in seconds.",
+			Buckets: prometheus.LinearBuckets(50, 50, 10),
+		},
+		[]string{buildStrategyLabel, namespaceLabel})
+)
+
+// InitPrometheus initializes the prometheus stuff
+func InitPrometheus(config *config.Config) {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(
+		buildCount,
+		buildRunCount,
+		buildRunEstablishDuration,
+		buildRunCompletionDuration,)
+}
+
+// BuildCountInc increases a number of the existing build total count
+func BuildCountInc(buildStrategy string) {
+	buildCount.WithLabelValues(buildStrategy).Inc()
+}
+
+// BuildCountInc increases a number of the existing build run total count
+func BuildRunCountInc(buildStrategy string) {
+	buildRunCount.WithLabelValues(buildStrategy).Inc()
+}
+
+// BuildRunEstablishObserve sets the build run establish time
+func BuildRunEstablishObserve(buildStrategy, namespace string, duration time.Duration) {
+	buildRunEstablishDuration.WithLabelValues(buildStrategy, namespace).Observe(duration.Seconds())
+}
+
+// BuildRunCompletionObserve sets the build run completion time
+func BuildRunCompletionObserve(buildStrategy, namespace string, duration time.Duration) {
+	buildRunCompletionDuration.WithLabelValues(buildStrategy, namespace).Observe(duration.Seconds())
+}

--- a/pkg/metrics/metrics_suite_test.go
+++ b/pkg/metrics/metrics_suite_test.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBuildRun(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"time"
+)
+
+var _ = Describe("Custom Metrics", func() {
+
+	var (
+		buildStrategy, namespace string
+	)
+
+	Context("when create a new kaniko buildrun", func() {
+		buildStrategy = "kaniko"
+		namespace = "default"
+
+		BuildCountInc(buildStrategy)
+		BuildRunCountInc(buildStrategy)
+		buildRunEstablishTime := time.Duration(1) * time.Second
+		buildRunExecutionTime := time.Duration(200) * time.Second
+		BuildRunEstablishObserve(buildStrategy, namespace, buildRunEstablishTime)
+		BuildRunCompletionObserve(buildStrategy, namespace, buildRunExecutionTime)
+
+		It("should increase the kaniko build count", func() {
+			buildCount, _ := buildCount.GetMetricWithLabelValues(buildStrategy)
+			Expect(testutil.ToFloat64(buildCount)).To(Equal(float64(1)))
+		})
+		It("should increase the kaniko buildrun count", func() {
+			buildRunCount, _ := buildRunCount.GetMetricWithLabelValues(buildStrategy)
+			Expect(testutil.ToFloat64(buildRunCount)).To(Equal(float64(1)))
+		})
+		It("should record the kaniko buildrun establish time", func() {
+			buildRunEstablishDuration, err := buildRunEstablishDuration.GetMetricWithLabelValues(buildStrategy, namespace)
+			Expect(buildRunEstablishDuration).NotTo(BeNil())
+			Expect(err).To(BeNil())
+		})
+		It("should record the kaniko buildrun completion time", func() {
+			buildRunCompletionDuration, err := buildRunCompletionDuration.GetMetricWithLabelValues(buildStrategy, namespace)
+			Expect(buildRunCompletionDuration).NotTo(BeNil())
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when create a new buildpacks buildrun", func() {
+		buildStrategy = "buildpacks"
+		namespace = "test"
+
+		BuildCountInc(buildStrategy)
+		BuildRunCountInc(buildStrategy)
+		buildRunEstablishTime := time.Duration(1) * time.Second
+		buildRunExecutionTime := time.Duration(100) * time.Second
+		BuildRunEstablishObserve(buildStrategy, namespace, buildRunEstablishTime)
+		BuildRunCompletionObserve(buildStrategy, namespace, buildRunExecutionTime)
+
+		It("should increase the buildpacks build count", func() {
+			buildCount, _ := buildCount.GetMetricWithLabelValues(buildStrategy)
+			Expect(testutil.ToFloat64(buildCount)).To(Equal(float64(1)))
+		})
+		It("should increase the buildpacks buildrun count", func() {
+			buildRunCount, _ := buildRunCount.GetMetricWithLabelValues(buildStrategy)
+			Expect(testutil.ToFloat64(buildRunCount)).To(Equal(float64(1)))
+		})
+		It("should record the buildpacks buildrun establish time", func() {
+			buildRunEstablishDuration, err := buildRunEstablishDuration.GetMetricWithLabelValues(buildStrategy, namespace)
+			Expect(buildRunEstablishDuration).NotTo(BeNil())
+			Expect(err).To(BeNil())
+		})
+		It("should record the buildpacks buildrun completion time", func() {
+			buildRunCompletionDuration, err := buildRunCompletionDuration.GetMetricWithLabelValues(buildStrategy, namespace)
+			Expect(buildRunCompletionDuration).NotTo(BeNil())
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -96,6 +96,7 @@ func (c *Catalog) BuildWithCustomAnnotationAndFinalizer(
 	a map[string]string,
 	f []string,
 ) *build.Build {
+	buildStrategy := build.ClusterBuildStrategyKind
 	return &build.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -106,6 +107,10 @@ func (c *Catalog) BuildWithCustomAnnotationAndFinalizer(
 		Spec: build.BuildSpec{
 			Source: build.GitSource{
 				URL: "foobar",
+			},
+			StrategyRef: &build.StrategyRef{
+				Name: strategyName,
+				Kind: &buildStrategy,
 			},
 		},
 	}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,214 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	m.Write(pb)
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCount collects all Metrics from the provided Collector and returns their number.
+//
+// This can be used to assert the number of metrics collected by a given collector after certain operations.
+//
+// This function is only for testing purposes, and even for testing, other approaches
+// are often more appropriate (see this package's documentation).
+func CollectAndCount(c prometheus.Collector) int {
+	var (
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	return mCount
+}
+
+// CollectAndCompare registers the provided Collector with a newly created
+// pedantic Registry. It then does the same as GatherAndCompare, gathering the
+// metrics from the pedantic Registry.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %s", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	got, err := g.Gather()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	var tp expfmt.TextParser
+	wantRaw, err := tp.TextToMetricFamilies(expected)
+	if err != nil {
+		return fmt.Errorf("parsing expected metrics failed: %s", err)
+	}
+	want := internal.NormalizeMetricFamilies(wantRaw)
+
+	return compare(got, want)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.FmtText)
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %s", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.FmtText)
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %s", err)
+		}
+	}
+
+	if wantBuf.String() != gotBuf.String() {
+		return fmt.Errorf(`
+metric output does not match expectation; want:
+
+%s
+got:
+
+%s`, wantBuf.String(), gotBuf.String())
+
+	}
+	return nil
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -173,6 +173,7 @@ github.com/pkg/errors
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
+github.com/prometheus/client_golang/prometheus/testutil
 # github.com/prometheus/client_model v0.2.0
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.9.1


### PR DESCRIPTION
Based in our controller implementations, I add 6 basic custom metrics:
- controller up status
- build count
- buildrun count
- buildrun establish time
- buildrun execution time
- buildrun execution time histogram

I also verified after the controller is retarted and the metrics is cleaned up, the later metrics can still show correctly.

I also add ut for metrics.

Here is the example metrics show from Sysdig:
<img width="1349" alt="截屏2020-05-29 上午11 59 30" src="https://user-images.githubusercontent.com/18108042/83219831-f9264f00-a1a3-11ea-8f34-57303815f1cf.png">
<img width="1349" alt="截屏2020-05-29 上午11 59 46" src="https://user-images.githubusercontent.com/18108042/83219839-fcb9d600-a1a3-11ea-9440-13971f7c6b63.png">


