### PR TITLE
Print the log of failed buildRun pod for debugging

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -26,6 +26,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			createBuild(namespace, "buildah", "samples/build/build_buildah_cr.yaml")
 		})
 
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "buildah")
+			}
+		})
+
 		It("successfully runs a build", func() {
 			br, err := buildRunTestData(namespace, "buildah", "samples/buildrun/buildrun_buildah_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
@@ -41,6 +48,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			createBuild(namespace, "buildah-custom-context-dockerfile", "test/data/build_buildah_cr_custom_context+dockerfile.yaml")
 		})
 
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "buildah-custom-context-dockerfile")
+			}
+		})
+
 		It("successfully runs a build", func() {
 			br, err := buildRunTestData(namespace, "buildah-custom-context-dockerfile", "test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
@@ -51,6 +65,14 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	})
 
 	Context("when a heroku Buildpacks build is defined using a cluster strategy", func() {
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "buildpacks-v3-heroku")
+			}
+		})
+
 		It("successfully runs a build", func() {
 			createBuild(namespace, "buildpacks-v3-heroku", "samples/build/build_buildpacks-v3-heroku_cr.yaml")
 			br, err := buildRunTestData(namespace, "buildpacks-v3-heroku", "samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml")
@@ -61,6 +83,14 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	})
 
 	Context("when a heroku Buildpacks build is defined using a namespaced strategy", func() {
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "buildpacks-v3-heroku-namespaced")
+			}
+		})
+
 		It("successfully runs a build", func() {
 			createBuild(namespace, "buildpacks-v3-heroku-namespaced", "samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml")
 			br, err := buildRunTestData(namespace, "buildpacks-v3-heroku-namespaced", "samples/buildrun/buildrun_buildpacks-v3-heroku_namespaced_cr.yaml")
@@ -71,6 +101,14 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	})
 
 	Context("when a Buildpacks v3 build is defined using a cluster strategy", func() {
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "buildpacks-v3")
+			}
+		})
+
 		It("successfully runs with a cluster scope strategy", func() {
 			createBuild(namespace, "buildpacks-v3", "samples/build/build_buildpacks-v3_cr.yaml")
 			br, err := buildRunTestData(namespace, "buildpacks-v3", "samples/buildrun/buildrun_buildpacks-v3_cr.yaml")
@@ -82,6 +120,14 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	})
 
 	Context("when a Buildpacks v3 build is defined using a namespaced strategy", func() {
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "buildpacks-v3-namespaced")
+			}
+		})
+
 		It("successfully runs a build", func() {
 			createBuild(namespace, "buildpacks-v3-namespaced", "samples/build/build_buildpacks-v3_namespaced_cr.yaml")
 			br, err := buildRunTestData(namespace, "buildpacks-v3-namespaced", "samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml")
@@ -92,6 +138,14 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	})
 
 	Context("when a Buildpacks v3 build is defined for a php runtime", func() {
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "buildpacks-v3-php")
+			}
+		})
+
 		It("successfully runs a build", func() {
 			createBuild(namespace, "buildpacks-v3-php", "test/data/build_buildpacks-v3_php_cr.yaml")
 			br, err := buildRunTestData(namespace, "buildpacks-v3-php", "test/data/buildrun_buildpacks-v3_php_cr.yaml")
@@ -102,6 +156,14 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	})
 
 	Context("when a Buildpacks v3 build is defined for a ruby runtime", func() {
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "buildpacks-v3-ruby")
+			}
+		})
+
 		It("successfully runs a build", func() {
 			createBuild(namespace, "buildpacks-v3-ruby", "test/data/build_buildpacks-v3_ruby_cr.yaml")
 			br, err := buildRunTestData(namespace, "buildpacks-v3-ruby", "test/data/buildrun_buildpacks-v3_ruby_cr.yaml")
@@ -112,6 +174,14 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	})
 
 	Context("when a Buildpacks v3 build is defined for a golang runtime", func() {
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "buildpacks-v3-golang")
+			}
+		})
+
 		It("successfully runs a build", func() {
 			createBuild(namespace, "buildpacks-v3-golang", "test/data/build_buildpacks-v3_golang_cr.yaml")
 			br, err := buildRunTestData(namespace, "buildpacks-v3-golang", "test/data/buildrun_buildpacks-v3_golang_cr.yaml")
@@ -122,6 +192,14 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	})
 
 	Context("when a Buildpacks v3 build is defined for a java runtime", func() {
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "buildpacks-v3-java")
+			}
+		})
+
 		It("successfully runs a build", func() {
 			createBuild(namespace, "buildpacks-v3-java", "test/data/build_buildpacks-v3_java_cr.yaml")
 			br, err := buildRunTestData(namespace, "buildpacks-v3-java", "test/data/buildrun_buildpacks-v3_java_cr.yaml")
@@ -136,6 +214,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		BeforeEach(func() {
 			// create the build definition
 			createBuild(namespace, "kaniko", "samples/build/build_kaniko_cr.yaml")
+		})
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "kaniko")
+			}
 		})
 
 		It("successfully runs a build", func() {
@@ -154,6 +239,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			createBuild(namespace, "kaniko-advanced-dockerfile", "test/data/build_kaniko_cr_advanced_dockerfile.yaml")
 		})
 
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "kaniko-advanced-dockerfile")
+			}
+		})
+
 		It("successfully runs a build", func() {
 			br, err := buildRunTestData(namespace, "kaniko-advanced-dockerfile", "test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
@@ -167,6 +259,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		BeforeEach(func() {
 			// create the build definition
 			createBuild(namespace, "kaniko-custom-context-dockerfile", "test/data/build_kaniko_cr_custom_context+dockerfile.yaml")
+		})
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "kaniko-custom-context-dockerfile")
+			}
 		})
 
 		It("successfully runs a build", func() {
@@ -184,6 +283,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			createBuild(namespace, "kaniko-timeout", "test/data/build_timeout.yaml")
 		})
 
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "kaniko-timeout")
+			}
+		})
+
 		It("fails the build run", func() {
 			br, err := buildRunTestData(namespace, "kaniko-timeout", "test/data/buildrun_timeout.yaml")
 			Expect(err).ToNot(HaveOccurred())
@@ -197,6 +303,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		BeforeEach(func() {
 			// create the build definition
 			createBuild(namespace, "s2i", "samples/build/build_source-to-image_cr.yaml")
+		})
+
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				Logf("Print failed BuildRun's log")
+				buildRunPodLogs(namespace, "s2i")
+			}
 		})
 
 		It("successfully runs a build", func() {
@@ -222,6 +335,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				createBuild(namespace, "private-github-buildah", "test/data/build_buildah_cr_private_github.yaml")
 			})
 
+			AfterEach(func() {
+				if CurrentGinkgoTestDescription().Failed {
+					Logf("Print failed BuildRun's log")
+					buildRunPodLogs(namespace, "private-github-buildah")
+				}
+			})
+
 			It("successfully runs a build", func() {
 				br, err := buildRunTestData(namespace, "private-github-buildah", "samples/buildrun/buildrun_buildah_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
@@ -235,6 +355,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			BeforeEach(func() {
 				// create the build definition
 				createBuild(namespace, "private-gitlab-buildah", "test/data/build_buildah_cr_private_gitlab.yaml")
+			})
+
+			AfterEach(func() {
+				if CurrentGinkgoTestDescription().Failed {
+					Logf("Print failed BuildRun's log")
+					buildRunPodLogs(namespace, "private-gitlab-buildah")
+				}
 			})
 
 			It("successfully runs a build", func() {
@@ -252,6 +379,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				createBuild(namespace, "private-github-kaniko", "test/data/build_kaniko_cr_private_github.yaml")
 			})
 
+			AfterEach(func() {
+				if CurrentGinkgoTestDescription().Failed {
+					Logf("Print failed BuildRun's log")
+					buildRunPodLogs(namespace, "private-github-kaniko")
+				}
+			})
+
 			It("successfully runs a build", func() {
 				br, err := buildRunTestData(namespace, "private-github-kaniko", "samples/buildrun/buildrun_kaniko_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
@@ -267,6 +401,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				createBuild(namespace, "private-gitlab-kaniko", "test/data/build_kaniko_cr_private_gitlab.yaml")
 			})
 
+			AfterEach(func() {
+				if CurrentGinkgoTestDescription().Failed {
+					Logf("Print failed BuildRun's log")
+					buildRunPodLogs(namespace, "private-gitlab-kaniko")
+				}
+			})
+
 			It("successfully runs a build", func() {
 				br, err := buildRunTestData(namespace, "private-gitlab-kaniko", "samples/buildrun/buildrun_kaniko_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
@@ -280,6 +421,13 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			BeforeEach(func() {
 				// create the build definition
 				createBuild(namespace, "private-github-s2i", "test/data/build_source-to-image_cr_private_github.yaml")
+			})
+
+			AfterEach(func() {
+				if CurrentGinkgoTestDescription().Failed {
+					Logf("Print failed BuildRun's log")
+					buildRunPodLogs(namespace, "private-github-s2i")
+				}
 			})
 
 			It("successfully runs a build", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -29,7 +29,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "buildah")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildah")
 			}
 		})
 
@@ -51,7 +51,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "buildah-custom-context-dockerfile")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildah-custom-context-dockerfile")
 			}
 		})
 
@@ -69,7 +69,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "buildpacks-v3-heroku")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-heroku")
 			}
 		})
 
@@ -87,7 +87,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "buildpacks-v3-heroku-namespaced")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-heroku-namespaced")
 			}
 		})
 
@@ -105,7 +105,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "buildpacks-v3")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3")
 			}
 		})
 
@@ -124,7 +124,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "buildpacks-v3-namespaced")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-namespaced")
 			}
 		})
 
@@ -142,7 +142,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "buildpacks-v3-php")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-php")
 			}
 		})
 
@@ -160,7 +160,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "buildpacks-v3-ruby")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-ruby")
 			}
 		})
 
@@ -178,7 +178,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "buildpacks-v3-golang")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-golang")
 			}
 		})
 
@@ -196,7 +196,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "buildpacks-v3-java")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-java")
 			}
 		})
 
@@ -219,7 +219,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "kaniko")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "kaniko")
 			}
 		})
 
@@ -242,7 +242,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "kaniko-advanced-dockerfile")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "kaniko-advanced-dockerfile")
 			}
 		})
 
@@ -264,7 +264,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "kaniko-custom-context-dockerfile")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "kaniko-custom-context-dockerfile")
 			}
 		})
 
@@ -286,7 +286,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "kaniko-timeout")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "kaniko-timeout")
 			}
 		})
 
@@ -308,7 +308,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				buildRunPodLogs(namespace, "s2i")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, "s2i")
 			}
 		})
 
@@ -338,7 +338,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					buildRunPodLogs(namespace, "private-github-buildah")
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, "private-github-buildah")
 				}
 			})
 
@@ -360,7 +360,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					buildRunPodLogs(namespace, "private-gitlab-buildah")
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, "private-gitlab-buildah")
 				}
 			})
 
@@ -382,7 +382,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					buildRunPodLogs(namespace, "private-github-kaniko")
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, "private-github-kaniko")
 				}
 			})
 
@@ -404,7 +404,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					buildRunPodLogs(namespace, "private-gitlab-kaniko")
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, "private-gitlab-kaniko")
 				}
 			})
 
@@ -426,7 +426,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					buildRunPodLogs(namespace, "private-github-s2i")
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, "private-github-s2i")
 				}
 			})
 


### PR DESCRIPTION
Related issue: https://github.com/redhat-developer/build/issues/230

Currently, if our e2e test failed in travis, then it will only report below error:
```
Timed out after 550.000s.
    BuildRun did not succeed
    Expected
        <v1.ConditionStatus>: False
    to equal
        <v1.ConditionStatus>: True
```
We can't get some useful information for debugging. And we also can't access the kind cluster to debug, this is inconvenient.

So this PR will print the log of builrRun when this buildRun failed. Then we can judge what's wrong with the buildRun.  
 
For example, if there is a failed case for `buildpacks-v3-heroku-namespaced` buildRun, then travis will output each container's log for the buildRun pod, like below:
```
For a Kubernetes cluster with Tekton and build installed when a heroku Buildpacks build is defined using a namespaced strategy 
  successfully runs a build
  /Users/xiangxiuli/go/src/github.com/redhat-developer/build/test/e2e/e2e_test.go:94

2020-06-01T06:46:19Z 1 Creating build buildpacks-v3-heroku-namespaced
2020-06-01T06:46:19Z 1 Amended object: name='buildpacks-v3-heroku-namespaced', image-url='us.icr.io/zoe_namespace/image1:buildpacks-v3-heroku-namespaced'
2020-06-01T06:46:19Z 1 Build buildpacks-v3-heroku-namespaced created
2020-06-01T06:46:20Z 1 TaskRun is not yet generated!
2020-06-01T06:55:39Z 1 Print failed BuildRun's log
2020-06-01T06:55:42Z 1 container is step-create-dir-image-pb2df
2020-06-01T06:55:42Z 1 container's log is 
2020-06-01T06:55:42Z 1 container is step-git-source-source-7j7zf
2020-06-01T06:55:42Z 1 container's log is {"level":"info","ts":1590993989.4624906,"caller":"git/git.go:105","msg":"Successfully cloned https://github.com/sclorg/nodejs-ex @ master in path /workspace/source"}
{"level":"warn","ts":1590993989.4627655,"caller":"git/git.go:152","msg":"Unexpected error: creating symlink: symlink /tekton/home/.ssh /root/.ssh: file exists"}
{"level":"info","ts":1590993989.5565746,"caller":"git/git.go:133","msg":"Successfully initialized and updated submodules in path /workspace/source"}

2020-06-01T06:55:43Z 1 container is step-step-prepare
2020-06-01T06:55:43Z 1 container's log is 
2020-06-01T06:55:44Z 1 container is step-step-detect
2020-06-01T06:55:44Z 1 container's log is heroku/nodejs-engine 0.4.3
heroku/nodejs-npm    0.1.4
heroku/procfile      0.5

2020-06-01T06:55:44Z 1 container is step-step-restore
2020-06-01T06:55:44Z 1 container's log is 
2020-06-01T06:55:44Z 1 container is step-step-build
2020-06-01T06:55:44Z 1 container's log is ---> Node.js Buildpack
---> Installing toolbox
---> - jq
---> - yj
---> Getting Node version
---> Resolving Node version
---> Downloading and extracting Node v12.17.0
---> Parsing package.json
---> Using npm v6.14.4 from Node
---> Installing node modules
npm WARN deprecated to-iso-string@0.0.2: to-iso-string has been deprecated, use @segment/to-iso-string instead.
npm WARN deprecated jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
npm WARN deprecated mkdirp@0.5.1: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm WARN deprecated mkdirp@0.3.0: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated bson@1.0.9: Fixed a critical issue with BSON serialization documented in CVE-2019-2391, see https://bit.ly/2KcpXdo for more details

> ejs@2.7.4 postinstall /workspace/source/node_modules/ejs
> node ./postinstall.js

Thank you for installing EJS: built with the Jake JavaScript build tool (https://jakejs.com/)

added 121 packages from 342 contributors and audited 121 packages in 13.129s
found 10 vulnerabilities (3 low, 2 moderate, 4 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
-----> Discovering process types
       Procfile declares types     -> (none)

2020-06-01T06:55:45Z 1 container is step-step-export
2020-06-01T06:55:45Z 1 container's log is flag provided but not defined: -test
Usage of /cnb/lifecycle/exporter:
  -analyzed string
        path to analyzed.toml (default "./analyzed.toml")
  -app string
        path to app directory (default "/workspace")
  -cache-dir string
        path to cache directory
  -cache-image string
        cache image tag name
  -daemon
        export to docker daemon
  -gid int
        GID of user's group in the stack's build and run images (default 1000)
  -group string
        path to group.toml (default "./group.toml")
  -helpers
        use credential helpers
  -image string
        reference to run image
  -launch-cache string
        path to launch cache directory
  -launcher string
        path to launcher binary (default "/cnb/lifecycle/launcher")
  -layers string
        path to layers directory (default "/layers")
  -log-level string
        logging level (default "info")
  -stack string
        path to stack.toml (default "/cnb/stack.toml")
  -uid int
        UID of user in the stack's build and run images (default 1000)
  -version
        show version

2020-06-01T06:55:45Z 1 container is step-image-digest-exporter-74zbn
2020-06-01T06:55:45Z 1 container's log is 2020/06/01 06:46:53 Skipping step because a previous step failed



• Failure [566.120 seconds]
For a Kubernetes cluster with Tekton and build installed
/Users/xiangxiuli/go/src/github.com/redhat-developer/build/test/e2e/e2e_test.go:10
  when a heroku Buildpacks build is defined using a namespaced strategy
  /Users/xiangxiuli/go/src/github.com/redhat-developer/build/test/e2e/e2e_test.go:85
    successfully runs a build [It]
    /Users/xiangxiuli/go/src/github.com/redhat-developer/build/test/e2e/e2e_test.go:94

    Timed out after 550.004s.
    BuildRun did not succeed
    Expected
        <v1.ConditionStatus>: False
    to equal
        <v1.ConditionStatus>: True
```
