### PR TITLE
Change controller HA to leader-for-lease mode

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -94,6 +94,9 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
+		LeaderElection: true,
+		LeaderElectionID: "build-operator-lock",
+		LeaderElectionNamespace: "default",
 		Namespace:          "",
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})


### PR DESCRIPTION
Fix issue: https://github.com/redhat-developer/build/issues/232

By investigating, I think we should use [`leader-for-lease`](https://docs.openshift.com/container-platform/4.2/operators/operator_sdk/osdk-leader-election.html#osdk-leader-with-lease-election_osdk-leader-election) operator-sdk controller HA solution instead of [`leader-for-life`](https://docs.openshift.com/container-platform/4.2/operators/operator_sdk/osdk-leader-election.html#osdk-leader-for-life-election_osdk-leader-election). More details, pls refer to:https://github.com/redhat-developer/build/issues/232

By default, `LeaseDuration` is 15s, `RenewDeadline` is 10s and `RetryPeriod` is 2s. We can [change the default value](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/manager#Options) in the future. But, I have checked default values are enough for us, now.

