### PR TITLE
Add liveness and readness probes on the operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,6 +17,10 @@ spec:
         - name: build-operator
           # Replace this with the built image name
           image: REPLACE_IMAGE
+          args:
+            - /bin/sh
+            - -c
+            - touch /tmp/build-operator-healthy
           command:
           - build-operator
           imagePullPolicy: Always
@@ -31,3 +35,17 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "build-operator"
+          livenessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/build-operator-healthy
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/build-operator-healthy
+            initialDelaySeconds: 5
+            periodSeconds: 10


### PR DESCRIPTION
- the liveness probes was added on the operator. It will help us to know when to restart the container by checking if the container is healthy or not. 
The setup args will be executed when the container starts, it is further be used for healthy check of the container.

- the readness probes will help us to know when the container is ready to receive the traffic as our definition(i.e. `initialDelaySeconds `, `periodSeconds `) in the probes.