### PR TITLE
Change kaniko BuildStrategy from latest image to v0.19.0

### DIFF
--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:latest
+      image: gcr.io/kaniko-project/executor:v0.19.0
       workingdir: /workspace/source
       securityContext:
         runAsUser: 0

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -27,7 +27,7 @@ spec:
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
-      image: 'gcr.io/kaniko-project/executor:latest'
+      image: 'gcr.io/kaniko-project/executor:v0.19.0'
       name: step-build-and-push
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
Change kaniko BuildStrategy from latest image to v0.19.0, because latest kaniko image has performance issue.