### PR TITLE
Enhance buildRun doc

### DIFF
--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -50,7 +50,7 @@ The `BuildRun` definition supports the following fields:
   - `spec.resources` - Refers to the compute [resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) used on the container where the image is built.
   - `spec.serviceAccount` - Refers to the SA to use when building the image. (_defaults to the `default` SA_)
   - `spec.timeout` - Defines a custom timeout. The value needs to be parsable by [ParseDuration](https://golang.org/pkg/time/#ParseDuration), for example `5m`. The value overwrites the value that is defined in the `Build`.
-  - `spec.output.image` - Refers to a custom location where the generated image would be pushed. The value will overwrite the `output.image` value which is defined in `Build`.
+  - `spec.output.image` - Refers to a custom location where the generated image would be pushed. The value will overwrite the `output.image` value which is defined in `Build`. ( Note: other properties of the output, for example, the credentials cannot be specified in the buildRun spec. )
 ### Defining the BuildRef
 
 A `BuildRun` resource can reference a `Build` resource, that indicates what image to build. For example:


### PR DESCRIPTION
Just for clarify image push `credential ` is not in the scope of override `output` field defined in build spec. Now, we just override output imageURL, don't include credential.