### PR TITLE
Improve logging and add proper go contexts

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -8,7 +8,8 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/go-logr/logr"
+	buildconfig "github.com/redhat-developer/build/pkg/config"
+
 	"github.com/redhat-developer/build/pkg/ctxlog"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -42,11 +43,11 @@ var (
 	operatorMetricsPort int32 = 8686
 )
 
-func printVersion(l logr.Logger) {
-	l.Info(fmt.Sprintf("Operator Version: %s", version.Version))
-	l.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	l.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	l.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+func printVersion(ctx context.Context) {
+	ctxlog.Info(ctx, fmt.Sprintf("Operator Version: %s", version.Version))
+	ctxlog.Info(ctx, fmt.Sprintf("Go Version: %s", runtime.Version()))
+	ctxlog.Info(ctx, fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	ctxlog.Info(ctx, fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
 }
 
 func main() {
@@ -70,70 +71,77 @@ func main() {
 	// uniform and structured logs.
 
 	l := ctxlog.NewLogger("build")
-	printVersion(l)
+
+	ctx := ctxlog.NewParentContext(l)
+
+	printVersion(ctx)
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
-		l.Error(err, "Failed to get watch namespace")
+		ctxlog.Error(ctx, err, "Failed to get watch namespace")
 		os.Exit(1)
 	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		l.Error(err, "")
+		ctxlog.Error(ctx, err, "")
 		os.Exit(1)
 	}
-
-	ctx := ctxlog.NewParentContext(l)
 
 	// Become the leader before proceeding
 	err = leader.Become(ctx, "build-operator-lock")
 	if err != nil {
-		l.Error(err, "")
+		ctxlog.Error(ctx, err, "")
 		os.Exit(1)
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		LeaderElection: true,
-		LeaderElectionID: "build-operator-lock",
+		LeaderElection:          true,
+		LeaderElectionID:        "build-operator-lock",
 		LeaderElectionNamespace: "default",
-		Namespace:          "",
-		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		Namespace:               "",
+		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})
 	if err != nil {
-		l.Error(err, "")
+		ctxlog.Error(ctx, err, "")
 		os.Exit(1)
 	}
 
-	l.Info("Registering Components.")
+	ctxlog.Info(ctx, "Registering Components.")
 
 	if err := v1beta1.AddToScheme(mgr.GetScheme()); err != nil {
-		l.Error(err, "")
+		ctxlog.Error(ctx, err, "")
 		os.Exit(1)
 	}
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		l.Error(err, "")
+		ctxlog.Error(ctx, err, "")
+		os.Exit(1)
+	}
+
+	c := buildconfig.NewDefaultConfig()
+	if err := c.SetConfigTimeOutFromEnv(); err != nil {
+		ctxlog.Error(ctx, err, "")
 		os.Exit(1)
 	}
 
 	// Setup all Controllers
-	if err := controller.AddToManager(ctx, mgr); err != nil {
-		l.Error(err, "")
+	if err := controller.AddToManager(ctx, c, mgr); err != nil {
+		ctxlog.Error(ctx, err, "")
 		os.Exit(1)
 	}
 
 	// Add the Metrics Service
 	addMetrics(ctx, cfg, namespace)
 
-	l.Info("Starting the Cmd.")
+	ctxlog.Info(ctx, "Starting the Cmd.")
 
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		l.Error(err, "Manager exited non-zero")
+		ctxlog.Error(ctx, err, "Manager exited non-zero")
 		os.Exit(1)
 	}
 }
@@ -141,13 +149,12 @@ func main() {
 // addMetrics will create the Services and Service Monitors to allow the operator export the metrics by using
 // the Prometheus operator
 func addMetrics(ctx context.Context, cfg *rest.Config, namespace string) {
-	l := ctxlog.ExtractLogger(ctx)
 	if err := serveCRMetrics(cfg); err != nil {
 		if errors.Is(err, k8sutil.ErrRunLocal) {
-			l.Info("Skipping CR metrics server creation; not running in a cluster.")
+			ctxlog.Info(ctx, "Skipping CR metrics server creation; not running in a cluster.")
 			return
 		}
-		l.Info("Could not generate and serve custom resource metrics", "error", err.Error())
+		ctxlog.Info(ctx, "Could not generate and serve custom resource metrics", "error", err.Error())
 	}
 
 	// Add to the below struct any other metrics ports you want to expose.
@@ -159,7 +166,7 @@ func addMetrics(ctx context.Context, cfg *rest.Config, namespace string) {
 	// Create Service object to expose the metrics port(s).
 	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
-		l.Info("Could not create metrics Service", "error", err.Error())
+		ctxlog.Info(ctx, "Could not create metrics Service", "error", err.Error())
 	}
 
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
@@ -167,11 +174,11 @@ func addMetrics(ctx context.Context, cfg *rest.Config, namespace string) {
 	services := []*v1.Service{service}
 	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
 	if err != nil {
-		l.Info("Could not create ServiceMonitor object", "error", err.Error())
+		ctxlog.Info(ctx, "Could not create ServiceMonitor object", "error", err.Error())
 		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
 		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
 		if err == metrics.ErrServiceMonitorNotPresent {
-			l.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
+			ctxlog.Info(ctx, "Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
 		}
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	contextTimeout = 300 * time.Second
+	// A number in seconds to define a context Timeout
+	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5
+	contexTimeoutEnvVar = "CTX_TIMEOUT"
+)
+
+// Config hosts different parameters that
+// can be set to use on the Build controllers
+type Config struct {
+	CtxTimeOut time.Duration
+}
+
+// NewDefaultConfig returns a new Config
+func NewDefaultConfig() *Config {
+	return &Config{
+		CtxTimeOut: contextTimeout,
+	}
+}
+
+// SetConfigTimeOutFromEnv updates the CtxTimeOut field
+// by consuming the value from an ENV variable.
+func (c *Config) SetConfigTimeOutFromEnv() error {
+	timeOut := os.Getenv(contexTimeoutEnvVar)
+	if timeOut != "" {
+		i, err := strconv.Atoi(timeOut)
+		if err != nil {
+			return err
+		}
+		c.CtxTimeOut = time.Duration(i) * time.Second
+	}
+	return nil
+}

--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -147,7 +147,7 @@ func (r *ReconcileBuild) Reconcile(request reconcile.Request) (reconcile.Result,
 	// Validate if the build strategy is defined
 	if b.Spec.StrategyRef != nil {
 		if err := r.validateStrategyRef(ctx, b.Spec.StrategyRef, b.Namespace); err != nil {
-			ctxlog.Error(ctx, err, "failed validating the strategy reference", b.Namespace, "Build", b.Name)
+			ctxlog.Error(ctx, err, "failed validating the strategy reference", "Build", b.Name)
 			b.Status.Reason = err.Error()
 			updateErr := r.client.Status().Update(ctx, b)
 			return reconcile.Result{}, fmt.Errorf("errors: %v %v", err, updateErr)

--- a/pkg/controller/build/build_controller_test.go
+++ b/pkg/controller/build/build_controller_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	build "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
+	"github.com/redhat-developer/build/pkg/config"
 	buildController "github.com/redhat-developer/build/pkg/controller/build"
 	"github.com/redhat-developer/build/pkg/controller/fakes"
 	"github.com/redhat-developer/build/pkg/ctxlog"
@@ -67,7 +68,7 @@ var _ = Describe("Reconcile Build", func() {
 		buildSample = ctl.BuildWithClusterBuildStrategy(buildName, namespace, buildStrategyName, registrySecret)
 		// Reconcile
 		testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
-		reconciler = buildController.NewReconciler(testCtx, manager)
+		reconciler = buildController.NewReconciler(testCtx, config.NewDefaultConfig(), manager)
 	})
 
 	Describe("Reconcile", func() {

--- a/pkg/controller/build/build_controller_test.go
+++ b/pkg/controller/build/build_controller_test.go
@@ -11,6 +11,7 @@ import (
 	build "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
 	buildController "github.com/redhat-developer/build/pkg/controller/build"
 	"github.com/redhat-developer/build/pkg/controller/fakes"
+	"github.com/redhat-developer/build/pkg/ctxlog"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -65,7 +66,8 @@ var _ = Describe("Reconcile Build", func() {
 		// Generate a Build CRD instance
 		buildSample = ctl.BuildWithClusterBuildStrategy(buildName, namespace, buildStrategyName, registrySecret)
 		// Reconcile
-		reconciler = buildController.NewReconciler(manager)
+		testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
+		reconciler = buildController.NewReconciler(testCtx, manager)
 	})
 
 	Describe("Reconcile", func() {

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -3,8 +3,12 @@ package buildrun
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
+
 	buildv1alpha1 "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
+	"github.com/redhat-developer/build/pkg/ctxlog"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,15 +22,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"strconv"
 )
-
-var log = logf.Log.WithName("controller_buildrun")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -37,8 +37,9 @@ type setOwnerReferenceFunc func(owner, object metav1.Object, scheme *runtime.Sch
 
 // Add creates a new BuildRun Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
-	return add(mgr, NewReconciler(mgr, controllerutil.SetControllerReference))
+func Add(ctx context.Context, mgr manager.Manager) error {
+	ctx = ctxlog.NewContext(ctx, "buildrun-controller")
+	return add(ctx, mgr, NewReconciler(ctx, mgr, controllerutil.SetControllerReference))
 }
 
 // blank assignment to verify that ReconcileBuildRun implements reconcile.Reconciler
@@ -48,14 +49,16 @@ var _ reconcile.Reconciler = &ReconcileBuildRun{}
 type ReconcileBuildRun struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
+	ctx                   context.Context
 	client                client.Client
 	scheme                *runtime.Scheme
 	setOwnerReferenceFunc setOwnerReferenceFunc
 }
 
 // NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(mgr manager.Manager, ownerRef setOwnerReferenceFunc) reconcile.Reconciler {
+func NewReconciler(ctx context.Context, mgr manager.Manager, ownerRef setOwnerReferenceFunc) reconcile.Reconciler {
 	return &ReconcileBuildRun{
+		ctx:                   ctx,
 		client:                mgr.GetClient(),
 		scheme:                mgr.GetScheme(),
 		setOwnerReferenceFunc: ownerRef,
@@ -63,7 +66,7 @@ func NewReconciler(mgr manager.Manager, ownerRef setOwnerReferenceFunc) reconcil
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
 	c, err := controller.New("buildrun-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -109,12 +112,16 @@ func handleError(message string, listOfErrors ...error) error {
 // Reconcile reads that state of the cluster for a Build object and makes changes based on the state read
 // and what is in the Build.Spec
 func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling BuildRun")
+
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := context.WithTimeout(r.ctx, 300*time.Second)
+	defer cancel()
+
+	ctxlog.Info(ctx, "Reconciling BuildRun", "Request.Namespace", request.Namespace, "Request.Name", request.Name)
 
 	// Fetch the BuildRun instance
 	buildRun := &buildv1alpha1.BuildRun{}
-	err := r.client.Get(context.TODO(), request.NamespacedName, buildRun)
+	err := r.client.Get(ctx, request.NamespacedName, buildRun)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return reconcile.Result{}, err
 	} else if apierrors.IsNotFound(err) {
@@ -123,9 +130,9 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	// Fetch the Build instance
 	build := &buildv1alpha1.Build{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: buildRun.Spec.BuildRef.Name, Namespace: buildRun.Namespace}, build)
+	err = r.client.Get(ctx, types.NamespacedName{Name: buildRun.Spec.BuildRef.Name, Namespace: buildRun.Namespace}, build)
 	if err != nil {
-		updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
+		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 		return reconcile.Result{}, handleError("Failed to fetch the Build instance", err, updateErr)
 	}
 
@@ -135,15 +142,15 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 	if buildRun.GetLabels()[buildv1alpha1.LabelBuild] == "" {
 		buildRun.Labels[buildv1alpha1.LabelBuild] = build.Name
 		buildRun.Labels[buildv1alpha1.LabelBuildGeneration] = strconv.FormatInt(build.Generation, 10)
-		err = r.client.Update(context.TODO(), buildRun)
+		err = r.client.Update(ctx, buildRun)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 	}
 
-	lastTaskRun, err := r.retrieveTaskRun(build, buildRun)
+	lastTaskRun, err := r.retrieveTaskRun(ctx, build, buildRun)
 	if err != nil {
-		updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
+		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 		return reconcile.Result{}, handleError(fmt.Sprintf("Failed to list existing TaskRuns from BuildRun: %v", buildRun.Name), err, updateErr)
 	}
 
@@ -164,7 +171,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 		if buildRun.Status.BuildSpec == nil {
 			buildRun.Status.BuildSpec = &build.Spec
 		}
-		err = r.client.Status().Update(context.TODO(), buildRun)
+		err = r.client.Status().Update(ctx, buildRun)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -172,9 +179,9 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 	}
 
 	// Choose a service account to use
-	serviceAccount, err := r.retrieveServiceAccount(build, buildRun)
+	serviceAccount, err := r.retrieveServiceAccount(ctx, build, buildRun)
 	if err != nil {
-		updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
+		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 		return reconcile.Result{}, handleError("Failed to choose a service account to use", err, updateErr)
 	}
 
@@ -182,56 +189,56 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 	// everything is in its desired state.
 	var generatedTaskRun *v1beta1.TaskRun
 	if build.Spec.StrategyRef.Kind == nil || *build.Spec.StrategyRef.Kind == buildv1alpha1.NamespacedBuildStrategyKind {
-		buildStrategy, err := r.retrieveBuildStrategy(build, request)
+		buildStrategy, err := r.retrieveBuildStrategy(ctx, build, request)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 		if buildStrategy != nil {
 			generatedTaskRun, err = GenerateTaskRun(build, buildRun, serviceAccount.Name, buildStrategy.Spec.BuildSteps)
 			if err != nil {
-				updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
+				updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 				return reconcile.Result{}, handleError("Failed to generate the taskrun with buildStrategy", err, updateErr)
 			}
 		}
 	} else if *build.Spec.StrategyRef.Kind == buildv1alpha1.ClusterBuildStrategyKind {
-		clusterBuildStrategy, err := r.retrieveClusterBuildStrategy(build, request)
+		clusterBuildStrategy, err := r.retrieveClusterBuildStrategy(ctx, build, request)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 		if clusterBuildStrategy != nil {
 			generatedTaskRun, err = GenerateTaskRun(build, buildRun, serviceAccount.Name, clusterBuildStrategy.Spec.BuildSteps)
 			if err != nil {
-				updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
+				updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 				return reconcile.Result{}, handleError("Failed to generate the taskrun with clusterBuildStrategy", err, updateErr)
 			}
 		}
 	} else {
 		err := fmt.Errorf("unknown strategy %s", string(*build.Spec.StrategyRef.Kind))
-		updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
+		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 		return reconcile.Result{}, handleError(fmt.Sprintf("Unsupported BuildStrategy Kind: %v", build.Spec.StrategyRef.Kind), err, updateErr)
 	}
 
 	// Set OwnerReference for Build and BuildRun
 	if err := r.setOwnerReferenceFunc(build, buildRun, r.scheme); err != nil {
-		updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
+		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 		return reconcile.Result{}, handleError("Failed to set OwnerReference for Build and BuildRun", err, updateErr)
 	}
 
 	// Set OwnerReference for BuildRun and TaskRun
 	if err := r.setOwnerReferenceFunc(buildRun, generatedTaskRun, r.scheme); err != nil {
-		updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
+		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 		return reconcile.Result{}, handleError("Failed to set OwnerReference for BuildRun and TaskRun", err, updateErr)
 	}
 
 	// create TaskRun if no TaskRun for that BuildRun exists
 	err = r.client.Create(context.TODO(), generatedTaskRun)
 	if err != nil {
-		updateErr := r.updateBuildRunErrorStatus(buildRun, err.Error())
+		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 		return reconcile.Result{}, handleError("Failed to create TaskRun if no TaskRun for that BuildRun exists", err, updateErr)
 	}
 
-	reqLogger.Info("Generate and create TaskRun from Build and BuildRun", "TaskRun", generatedTaskRun.Name, "Build", build.Name, "BuildRun", buildRun.Name)
-	reqLogger.Info("Reconciled Build", "Build.Namespace", buildRun.Namespace, "Build.Name", buildRun.Name)
+	ctxlog.Info(ctx, "Generate and create TaskRun from Build and BuildRun", "TaskRun", generatedTaskRun.Name, "Build", build.Name, "BuildRun", buildRun.Name)
+	ctxlog.Info(ctx, "Reconciled Build", "Build.Namespace", buildRun.Namespace, "Build.Name", buildRun.Name)
 	return reconcile.Result{}, nil
 }
 
@@ -243,7 +250,7 @@ func isTaskRunRunning(tr *v1beta1.TaskRun) bool {
 	return tr.Status.GetCondition(apis.ConditionSucceeded).IsUnknown()
 }
 
-func (r *ReconcileBuildRun) retrieveServiceAccount(build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun) (*corev1.ServiceAccount, error) {
+func (r *ReconcileBuildRun) retrieveServiceAccount(ctx context.Context, build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun) (*corev1.ServiceAccount, error) {
 	serviceAccount := &corev1.ServiceAccount{}
 	serviceAccountName := buildRun.Name + "-sa"
 	if buildRun.Spec.ServiceAccount != nil && buildRun.Spec.ServiceAccount.Generate == true {
@@ -259,7 +266,7 @@ func (r *ReconcileBuildRun) retrieveServiceAccount(build *buildv1alpha1.Build, b
 		if err != nil {
 			return nil, err
 		}
-		log.Info("Generate a new ServiceAccount for BuildRun", "ServiceAccount", serviceAccount.Name)
+		ctxlog.Info(ctx, "Generate a new ServiceAccount for BuildRun", "ServiceAccount", serviceAccount.Name)
 	} else {
 		// If ServiceAccount or the name of ServiceAccount in buildRun is nil, use pipeline serviceaccount
 		if buildRun.Spec.ServiceAccount == nil || buildRun.Spec.ServiceAccount.Name == nil {
@@ -288,34 +295,34 @@ func (r *ReconcileBuildRun) retrieveServiceAccount(build *buildv1alpha1.Build, b
 		if err != nil {
 			return nil, err
 		}
-		log.Info("Retrieve ServiceAccount from BuildRun", "ServiceAccount", serviceAccount.Name)
+		ctxlog.Info(ctx, "Retrieve ServiceAccount from BuildRun", "ServiceAccount", serviceAccount.Name)
 	}
 	return serviceAccount, nil
 }
 
-func (r *ReconcileBuildRun) retrieveBuildStrategy(instance *buildv1alpha1.Build, request reconcile.Request) (*buildv1alpha1.BuildStrategy, error) {
+func (r *ReconcileBuildRun) retrieveBuildStrategy(ctx context.Context, instance *buildv1alpha1.Build, request reconcile.Request) (*buildv1alpha1.BuildStrategy, error) {
 	buildStrategyInstance := &buildv1alpha1.BuildStrategy{}
 
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.StrategyRef.Name, Namespace: instance.Namespace}, buildStrategyInstance)
+	err := r.client.Get(ctx, types.NamespacedName{Name: instance.Spec.StrategyRef.Name, Namespace: instance.Namespace}, buildStrategyInstance)
 	if err != nil {
-		log.Error(err, "Failed to get BuildStrategy")
+		ctxlog.Error(ctx, err, "Failed to get BuildStrategy")
 		return nil, err
 	}
 	return buildStrategyInstance, nil
 }
 
-func (r *ReconcileBuildRun) retrieveClusterBuildStrategy(instance *buildv1alpha1.Build, request reconcile.Request) (*buildv1alpha1.ClusterBuildStrategy, error) {
+func (r *ReconcileBuildRun) retrieveClusterBuildStrategy(ctx context.Context, instance *buildv1alpha1.Build, request reconcile.Request) (*buildv1alpha1.ClusterBuildStrategy, error) {
 	clusterBuildStrategyInstance := &buildv1alpha1.ClusterBuildStrategy{}
 
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.StrategyRef.Name}, clusterBuildStrategyInstance)
+	err := r.client.Get(ctx, types.NamespacedName{Name: instance.Spec.StrategyRef.Name}, clusterBuildStrategyInstance)
 	if err != nil {
-		log.Error(err, "Failed to get ClusterBuildStrategy")
+		ctxlog.Error(ctx, err, "Failed to get ClusterBuildStrategy")
 		return nil, err
 	}
 	return clusterBuildStrategyInstance, nil
 }
 
-func (r *ReconcileBuildRun) retrieveTaskRun(build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun) (*v1beta1.TaskRun, error) {
+func (r *ReconcileBuildRun) retrieveTaskRun(ctx context.Context, build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun) (*v1beta1.TaskRun, error) {
 
 	taskRunList := &v1beta1.TaskRunList{}
 
@@ -327,7 +334,7 @@ func (r *ReconcileBuildRun) retrieveTaskRun(build *buildv1alpha1.Build, buildRun
 		Namespace:     buildRun.Namespace,
 		LabelSelector: labels.SelectorFromSet(lbls),
 	}
-	err := r.client.List(context.TODO(), taskRunList, &opts)
+	err := r.client.List(ctx, taskRunList, &opts)
 
 	if err != nil {
 		return nil, err
@@ -339,11 +346,11 @@ func (r *ReconcileBuildRun) retrieveTaskRun(build *buildv1alpha1.Build, buildRun
 	return nil, nil
 }
 
-func (r *ReconcileBuildRun) updateBuildRunErrorStatus(buildRun *buildv1alpha1.BuildRun, errorMessage string) error {
+func (r *ReconcileBuildRun) updateBuildRunErrorStatus(ctx context.Context, buildRun *buildv1alpha1.BuildRun, errorMessage string) error {
 	buildRun.Status.Succeeded = corev1.ConditionFalse
 	buildRun.Status.Reason = errorMessage
 	now := metav1.Now()
 	buildRun.Status.StartTime = &now
-	updateErr := r.client.Status().Update(context.TODO(), buildRun)
+	updateErr := r.client.Status().Update(ctx, buildRun)
 	return updateErr
 }

--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -10,6 +10,7 @@ import (
 	build "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
 	buildrunctl "github.com/redhat-developer/build/pkg/controller/buildrun"
 	"github.com/redhat-developer/build/pkg/controller/fakes"
+	"github.com/redhat-developer/build/pkg/ctxlog"
 	"github.com/redhat-developer/build/test"
 	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -95,7 +96,8 @@ var _ = Describe("Reconcile BuildRun", func() {
 	// this ensures that overrides on the BuildRun resource can happen under each
 	// Context() BeforeEach() block
 	JustBeforeEach(func() {
-		reconciler = buildrunctl.NewReconciler(manager, controllerutil.SetControllerReference)
+		testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
+		reconciler = buildrunctl.NewReconciler(testCtx, manager, controllerutil.SetControllerReference)
 		request = newReconcileRequest(buildRunSample)
 
 	})
@@ -229,7 +231,8 @@ var _ = Describe("Reconcile BuildRun", func() {
 					ctl.DefaultNamespacedBuildStrategy()),
 				)
 
-				reconciler = buildrunctl.NewReconciler(manager,
+				testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
+				reconciler = buildrunctl.NewReconciler(testCtx, manager,
 					func(owner, object metav1.Object, scheme *runtime.Scheme) error {
 						return fmt.Errorf("foobar error")
 					})

--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-developer/build/pkg/apis"
 	build "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
+	"github.com/redhat-developer/build/pkg/config"
 	buildrunctl "github.com/redhat-developer/build/pkg/controller/buildrun"
 	"github.com/redhat-developer/build/pkg/controller/fakes"
 	"github.com/redhat-developer/build/pkg/ctxlog"
@@ -97,7 +98,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 	// Context() BeforeEach() block
 	JustBeforeEach(func() {
 		testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
-		reconciler = buildrunctl.NewReconciler(testCtx, manager, controllerutil.SetControllerReference)
+		reconciler = buildrunctl.NewReconciler(testCtx, config.NewDefaultConfig(), manager, controllerutil.SetControllerReference)
 		request = newReconcileRequest(buildRunSample)
 
 	})
@@ -232,7 +233,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 				)
 
 				testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
-				reconciler = buildrunctl.NewReconciler(testCtx, manager,
+				reconciler = buildrunctl.NewReconciler(testCtx, config.NewDefaultConfig(), manager,
 					func(owner, object metav1.Object, scheme *runtime.Scheme) error {
 						return fmt.Errorf("foobar error")
 					})

--- a/pkg/controller/buildstrategy/buildstrategy_controller.go
+++ b/pkg/controller/buildstrategy/buildstrategy_controller.go
@@ -1,32 +1,38 @@
 package buildstrategy
 
 import (
+	"context"
+	"time"
+
 	buildv1alpha1 "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
+	"github.com/redhat-developer/build/pkg/ctxlog"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller_buildstrategy")
-
 // Add creates a new BuildStrategy Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
-	return add(mgr, NewReconciler(mgr))
+func Add(ctx context.Context, mgr manager.Manager) error {
+	ctx = ctxlog.NewContext(ctx, "buildstrategy-controller")
+	return add(ctx, mgr, NewReconciler(ctx, mgr))
 }
 
 // NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileBuildStrategy{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+func NewReconciler(ctx context.Context, mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileBuildStrategy{
+		ctx:    ctx,
+		client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
 	c, err := controller.New("buildstrategy-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -49,6 +55,7 @@ var _ reconcile.Reconciler = &ReconcileBuildStrategy{}
 type ReconcileBuildStrategy struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
+	ctx    context.Context
 	client client.Client
 	scheme *runtime.Scheme
 }
@@ -56,7 +63,11 @@ type ReconcileBuildStrategy struct {
 // Reconcile reads that state of the cluster for a BuildStrategy object and makes changes based on the state read
 // and what is in the BuildStrategy.Spec
 func (r *ReconcileBuildStrategy) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling BuildStrategy")
+
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := context.WithTimeout(r.ctx, 300*time.Second)
+	defer cancel()
+
+	ctxlog.Info(ctx, "Reconciling BuildStrategy", "Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/buildstrategy/buildstrategy_controller_test.go
+++ b/pkg/controller/buildstrategy/buildstrategy_controller_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-developer/build/pkg/config"
 	buildstrategyController "github.com/redhat-developer/build/pkg/controller/buildstrategy"
 	"github.com/redhat-developer/build/pkg/controller/fakes"
 	"github.com/redhat-developer/build/pkg/ctxlog"
@@ -32,7 +33,7 @@ var _ = Describe("Reconcile BuildStrategy", func() {
 	JustBeforeEach(func() {
 		// Reconcile
 		testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
-		reconciler = buildstrategyController.NewReconciler(testCtx, manager)
+		reconciler = buildstrategyController.NewReconciler(testCtx, config.NewDefaultConfig(), manager)
 	})
 
 	Describe("Reconcile", func() {

--- a/pkg/controller/buildstrategy/buildstrategy_controller_test.go
+++ b/pkg/controller/buildstrategy/buildstrategy_controller_test.go
@@ -1,10 +1,13 @@
 package buildstrategy_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	buildstrategyController "github.com/redhat-developer/build/pkg/controller/buildstrategy"
 	"github.com/redhat-developer/build/pkg/controller/fakes"
+	"github.com/redhat-developer/build/pkg/ctxlog"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -28,7 +31,8 @@ var _ = Describe("Reconcile BuildStrategy", func() {
 
 	JustBeforeEach(func() {
 		// Reconcile
-		reconciler = buildstrategyController.NewReconciler(manager)
+		testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
+		reconciler = buildstrategyController.NewReconciler(testCtx, manager)
 	})
 
 	Describe("Reconcile", func() {

--- a/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go
+++ b/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go
@@ -2,9 +2,9 @@ package clusterbuildstrategy
 
 import (
 	"context"
-	"time"
 
 	buildv1alpha1 "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
+	"github.com/redhat-developer/build/pkg/config"
 	"github.com/redhat-developer/build/pkg/ctxlog"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,15 +17,16 @@ import (
 
 // Add creates a new ClusterBuildStrategy Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(ctx context.Context, mgr manager.Manager) error {
+func Add(ctx context.Context, c *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContext(ctx, "clusterbuildstrategy-controller")
-	return add(ctx, mgr, NewReconciler(ctx, mgr))
+	return add(ctx, mgr, NewReconciler(ctx, c, mgr))
 }
 
 // NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(ctx context.Context, mgr manager.Manager) reconcile.Reconciler {
+func NewReconciler(ctx context.Context, c *config.Config, mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileClusterBuildStrategy{
 		ctx:    ctx,
+		config: c,
 		client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
 	}
@@ -56,6 +57,7 @@ type ReconcileClusterBuildStrategy struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	ctx    context.Context
+	config *config.Config
 	client client.Client
 	scheme *runtime.Scheme
 }
@@ -65,7 +67,7 @@ type ReconcileClusterBuildStrategy struct {
 func (r *ReconcileClusterBuildStrategy) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 
 	// Set the ctx to be Background, as the top-level context for incoming requests.
-	ctx, cancel := context.WithTimeout(r.ctx, 300*time.Second)
+	ctx, cancel := context.WithTimeout(r.ctx, r.config.CtxTimeOut)
 	defer cancel()
 
 	ctxlog.Info(ctx, "Reconciling ClusterBuildStrategy", "Request.Namespace", request.Namespace, "Request.Name", request.Name)

--- a/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go
+++ b/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go
@@ -1,32 +1,38 @@
 package clusterbuildstrategy
 
 import (
+	"context"
+	"time"
+
 	buildv1alpha1 "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
+	"github.com/redhat-developer/build/pkg/ctxlog"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller_clusterbuildstrategy")
-
 // Add creates a new ClusterBuildStrategy Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
-	return add(mgr, NewReconciler(mgr))
+func Add(ctx context.Context, mgr manager.Manager) error {
+	ctx = ctxlog.NewContext(ctx, "clusterbuildstrategy-controller")
+	return add(ctx, mgr, NewReconciler(ctx, mgr))
 }
 
 // NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileClusterBuildStrategy{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+func NewReconciler(ctx context.Context, mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileClusterBuildStrategy{
+		ctx:    ctx,
+		client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
 	c, err := controller.New("clusterbuildstrategy-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -49,6 +55,7 @@ var _ reconcile.Reconciler = &ReconcileClusterBuildStrategy{}
 type ReconcileClusterBuildStrategy struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
+	ctx    context.Context
 	client client.Client
 	scheme *runtime.Scheme
 }
@@ -56,7 +63,11 @@ type ReconcileClusterBuildStrategy struct {
 // Reconcile reads that state of the cluster for a ClusterBuildStrategy object and makes changes based on the state read
 // and what is in the BuildStrategy.Spec
 func (r *ReconcileClusterBuildStrategy) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling ClusterBuildStrategy")
+
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := context.WithTimeout(r.ctx, 300*time.Second)
+	defer cancel()
+
+	ctxlog.Info(ctx, "Reconciling ClusterBuildStrategy", "Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller_test.go
+++ b/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller_test.go
@@ -1,20 +1,23 @@
 package clusterbuildstrategy_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	clusterbuildstrategyController "github.com/redhat-developer/build/pkg/controller/clusterbuildstrategy"
 	"github.com/redhat-developer/build/pkg/controller/fakes"
+	"github.com/redhat-developer/build/pkg/ctxlog"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var _ = Describe("Reconcile ClusterBuildStrategy", func() {
 	var (
-		manager                      *fakes.FakeManager
-		reconciler                   reconcile.Reconciler
-		request                      reconcile.Request
-		buildStrategyName            string
+		manager           *fakes.FakeManager
+		reconciler        reconcile.Reconciler
+		request           reconcile.Request
+		buildStrategyName string
 	)
 
 	BeforeEach(func() {
@@ -27,7 +30,8 @@ var _ = Describe("Reconcile ClusterBuildStrategy", func() {
 
 	JustBeforeEach(func() {
 		// Reconcile
-		reconciler = clusterbuildstrategyController.NewReconciler(manager)
+		testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
+		reconciler = clusterbuildstrategyController.NewReconciler(testCtx, manager)
 	})
 
 	Describe("Reconcile", func() {

--- a/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller_test.go
+++ b/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-developer/build/pkg/config"
 	clusterbuildstrategyController "github.com/redhat-developer/build/pkg/controller/clusterbuildstrategy"
 	"github.com/redhat-developer/build/pkg/controller/fakes"
 	"github.com/redhat-developer/build/pkg/ctxlog"
@@ -31,7 +32,7 @@ var _ = Describe("Reconcile ClusterBuildStrategy", func() {
 	JustBeforeEach(func() {
 		// Reconcile
 		testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
-		reconciler = clusterbuildstrategyController.NewReconciler(testCtx, manager)
+		reconciler = clusterbuildstrategyController.NewReconciler(testCtx, config.NewDefaultConfig(), manager)
 	})
 
 	Describe("Reconcile", func() {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,16 +1,18 @@
 package controller
 
 import (
+	"context"
+
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []func(context.Context, manager.Manager) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
+func AddToManager(ctx context.Context, m manager.Manager) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(ctx, m); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -3,16 +3,18 @@ package controller
 import (
 	"context"
 
+	"github.com/redhat-developer/build/pkg/config"
+
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(context.Context, manager.Manager) error
+var AddToManagerFuncs []func(context.Context, *config.Config, manager.Manager) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(ctx context.Context, m manager.Manager) error {
+func AddToManager(ctx context.Context, c *config.Config, m manager.Manager) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(ctx, m); err != nil {
+		if err := f(ctx, c, m); err != nil {
 			return err
 		}
 	}

--- a/pkg/ctxlog/context.go
+++ b/pkg/ctxlog/context.go
@@ -1,0 +1,42 @@
+package ctxlog
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+type contextLogger struct{}
+
+var (
+	loggerKey = &contextLogger{}
+)
+
+// NewParentContext returns a new context from the
+// parent context.Background one. This new context
+// stores our logger implementation
+func NewParentContext(log logr.Logger) context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, loggerKey, log)
+	return ctx
+}
+
+// NewContext returns a new child context based on our logger
+// key(loggerKey). This function is useful for spawning children
+// context with a particular logging name for each controller
+func NewContext(ctx context.Context, name string) context.Context {
+	log := ExtractLogger(ctx)
+	log = log.WithName(name)
+	return context.WithValue(ctx, loggerKey, log)
+}
+
+// ExtractLogger returns a logger based on the loggerKey
+// This function retrieves from an existing context the value,
+// which in this case is an instance of our logger
+func ExtractLogger(ctx context.Context) logr.Logger {
+	log, ok := ctx.Value(loggerKey).(logr.Logger)
+	if !ok || log == nil {
+		return nil
+	}
+	return log
+}

--- a/pkg/ctxlog/context.go
+++ b/pkg/ctxlog/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type contextLogger struct{}
@@ -36,7 +37,7 @@ func NewContext(ctx context.Context, name string) context.Context {
 func ExtractLogger(ctx context.Context) logr.Logger {
 	log, ok := ctx.Value(loggerKey).(logr.Logger)
 	if !ok || log == nil {
-		return nil
+		return logf.NullLogger{}
 	}
 	return log
 }

--- a/pkg/ctxlog/log.go
+++ b/pkg/ctxlog/log.go
@@ -1,0 +1,40 @@
+package ctxlog
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// NewLogger returns a new Logger instance
+// by using the operator-sdk log/zap logging
+// implementation
+func NewLogger(name string) logr.Logger {
+	l := zap.Logger()
+
+	logf.SetLogger(l)
+
+	l = l.WithName(name)
+
+	return l
+}
+
+// Error returns an ERROR level log from an specified context
+func Error(ctx context.Context, err error, msg string, v ...interface{}) {
+	l := ExtractLogger(ctx)
+	l.Error(err, msg, v...)
+}
+
+// Debug returns an DEBUG level log from an specified context
+func Debug(ctx context.Context, msg string, v ...interface{}) {
+	l := ExtractLogger(ctx)
+	l.V(1).Info(msg, v...)
+}
+
+// Info returns an INFO level log from an specified context
+func Info(ctx context.Context, msg string, v ...interface{}) {
+	l := ExtractLogger(ctx)
+	l.Info(msg, v...)
+}

--- a/pkg/ctxlog/log.go
+++ b/pkg/ctxlog/log.go
@@ -11,30 +11,30 @@ import (
 // NewLogger returns a new Logger instance
 // by using the operator-sdk log/zap logging
 // implementation
-func NewLogger(name string) logr.Logger {
+func NewLogger(name string) *logr.Logger {
 	l := zap.Logger()
 
 	logf.SetLogger(l)
 
 	l = l.WithName(name)
 
-	return l
+	return &l
 }
 
 // Error returns an ERROR level log from an specified context
 func Error(ctx context.Context, err error, msg string, v ...interface{}) {
 	l := ExtractLogger(ctx)
-	l.Error(err, msg, v...)
+	(*l).Error(err, msg, v...)
 }
 
 // Debug returns an DEBUG level log from an specified context
 func Debug(ctx context.Context, msg string, v ...interface{}) {
 	l := ExtractLogger(ctx)
-	l.V(1).Info(msg, v...)
+	(*l).V(1).Info(msg, v...)
 }
 
 // Info returns an INFO level log from an specified context
 func Info(ctx context.Context, msg string, v ...interface{}) {
 	l := ExtractLogger(ctx)
-	l.Info(msg, v...)
+	(*l).Info(msg, v...)
 }


### PR DESCRIPTION
Based on #247 

This PR have quite a lot of changes, none of them is a breaking change. Each commit have a good explanation, but here is a summary:

- Introduce a new package call `ctxlog`. This package will provide us with a logging implementation. This package is using the same logging as before, but it just defines common functions that can be accessed from all controllers by passing a context. Also, this package uses a proper go context implementation. We start with a parent context in `main.go` and inside each build controller we get a children context. With this context we can then pass a proper context to all the `client` calls we do to k8s during Reconciliation. Now all client calls to k8s goes with a context that have a timeout, this should ensure that calls that take too much are aborted after the timeout, avoiding overloading the system.
  - The context timeout is configurable via an ENV variable("CTX_TIMEOUT"). I did this thinking in our `Deployment` YAML, where we can always define it via `spec.container.env`. It also have a reasonable default which is `300 seconds`, meaning that all k8s API calls have 300 seconds as a timeout to finish.
  - With ctxlog we get a more readable controller logs, for example:
```
2020-06-04T02:03:24.089+0200	INFO	build	Operator Version: 0.0.1
2020-06-04T02:03:24.089+0200	INFO	build	Go Version: go1.14.2
2020-06-04T02:03:24.089+0200	INFO	build	Go OS/Arch: darwin/amd64
2020-06-04T02:03:24.089+0200	INFO	build	Version of operator-sdk: v0.17.0
2020-06-04T02:03:27.318+0200	INFO	build	Starting the Cmd.
2020-06-04T02:03:27.521+0200	INFO	build.clusterbuildstrategy-controller	Reconciling ClusterBuildStrategy	{"Request.Namespace": "", "Request.Name": "kaniko"}
2020-06-04T02:03:27.521+0200	INFO	build.clusterbuildstrategy-controller	Reconciling ClusterBuildStrategy	{"Request.Namespace": "", "Request.Name": "source-to-image"}
2020-06-04T02:03:27.521+0200	INFO	build.clusterbuildstrategy-controller	Reconciling ClusterBuildStrategy	{"Request.Namespace": "", "Request.Name": "source-to-image-redhat"}
2020-06-04T02:03:27.521+0200	INFO	build.clusterbuildstrategy-controller	Reconciling ClusterBuildStrategy	{"Request.Namespace": "", "Request.Name": "buildpacks-v3-heroku"}
2020-06-04T02:03:27.521+0200	INFO	build.clusterbuildstrategy-controller	Reconciling ClusterBuildStrategy	{"Request.Namespace": "", "Request.Name": "buildpacks-v3"}
2020-06-04T02:03:34.170+0200	INFO	build.build-controller	reconciling Build	{"Request.Namespace": "default", "Request.Name": "kaniko-golang-build"}
2020-06-04T02:03:34.170+0200	INFO	build.build-controller	Add finalizer to Build	{"Build": "kaniko-golang-build", "Namespace": "default"}
2020-06-04T02:04:40.444+0200	INFO	build.build-controller	reconciling Build	{"Request.Namespace": "default", "Request.Name": "kaniko-golang-build"}
2020-06-04T02:04:40.444+0200	DEBUG	build.build-controller	build is marked for deletion	{"Request.Namespace": "default", "Request.Name": "kaniko-golang-build"}
2020-06-04T02:04:40.444+0200	INFO	build.build-controller	Finalize BuildRun automatically	{"Request.Namespace": "default", "Request.Name": "kaniko-golang-buildrun"}
```

- Introduce a new pkg call `config`. This is intended to host all configurations we might need to use in the controllers later on. At the moment it only defines a field for the above context timeout. In the future we might use this to host other things.

_Note_: Each commit have a good explanation. I think we still need to improve the logs we dump into STDOUT. Mainly INFO and DEBUG. I will follow up on this after this PR.
