### PR TITLE
Remove inactive users

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,18 +2,15 @@
 
 approvers:
 - sbose78
-- baijum
 - otaviof
 - zhangtbj
 - qu1queee
 
 reviewers:
 - sbose78
-- baijum
 - otaviof
 - akashshinde
 - DhritiShikhar
-- Avni-Sharma
 - pmacik
 - pratikjagrut
 - isutton


### PR DESCRIPTION
In this project, automatically two reviewers get assigned from the OWNERS file. In the two months that I am working on this project, I have not seen any review comments from the users `baijum` and `Avni-Sharma`. I am therefore proposing to remove them for the time being to get more meaningful auto-assigned reviewers.