### PR TITLE
Inline BuildStrategy CRDs with ClusterBuildStrategy

### DIFF
--- a/deploy/crds/build.dev_buildstrategies_crd.yaml
+++ b/deploy/crds/build.dev_buildstrategies_crd.yaml
@@ -3,11 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: buildstrategies.build.dev
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.strategy.kind
-    description: The BuildStrategy type which is used for this Build
-    name: Version
-    type: string
   group: build.dev
   names:
     kind: BuildStrategy

--- a/pkg/apis/build/v1alpha1/buildstrategy_types.go
+++ b/pkg/apis/build/v1alpha1/buildstrategy_types.go
@@ -25,7 +25,6 @@ type BuildStrategyStatus struct {
 // BuildStrategy is the Schema for the buildstrategies API
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=buildstrategies,scope=Namespaced,shortName=bs;bss
-// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.strategy.kind",description="The BuildStrategy type which is used for this Build"
 type BuildStrategy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Related to #228 

The namespaced BuildStrategy was defining a `VERSION` column
that the ClusterBuildStrategy didn´t have. Also, this `VERSION`
column didn´t display anything.

This commit removes the kubebuilder annotation from the
buildstrategy_types.go and regenerate the proper CRD for this resource.

This is how the strategies CRDs looked before:
```sh
$ k -n test-build get bs
NAME            VERSION
buildpacks-v3
$ k -n test-build get cbs
NAME                     AGE
buildah                  6m11s
buildpacks-v3            6m24s
buildpacks-v3-heroku     6m26s
kaniko                   6m8s
source-to-image          6m6s
source-to-image-redhat   6m3s
```
this is how they look with this PR:
```sh
$ k -n test-build get bs
NAME            AGE
buildpacks-v3   2m9s
$ k -n test-build get cbs
NAME                     AGE
buildah                  2m14s
buildpacks-v3            2m19s
buildpacks-v3-heroku     2m22s
kaniko                   2m11s
source-to-image          2m9s
source-to-image-redhat   2m6s
```
@zhangtbj in #228 you mentioned about having both version and age. I´m not sure why we would need `version` at this point in time. My rational is that this resources are most of the time only applied once, therefore a version becomes not that relevant. I would like first to inline both strategy CRDs with the same columns.

