### PR TITLE
remove ruby e2e test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -157,6 +157,11 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 	Context("when a Buildpacks v3 build is defined for a ruby runtime", func() {
 
+		BeforeEach(func() {
+			// issue track in paketo side: https://github.com/paketo-community/ruby/issues/59
+			Skip("Skipping test case because Ruby support in paketo is still under development.")
+		})
+
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")


### PR DESCRIPTION
Fix issue: https://github.com/redhat-developer/build/issues/256

Current ruby runtime for paketo looks like is in development and unstable, so we need to remove it first. Otherwise our travis alway failed because can't detect ruby buildpack.
```
{"level":"info","ts":1591328779.063402,"caller":"git/git.go:133","msg":"Successfully initialized and updated submodules in path /workspace/source"}
ERROR: No buildpack groups passed detection.
ERROR: Please check that you are running against the correct path.
ERROR: failed to detect: no buildpacks participating
2020/06/05 03:46:20 Skipping step because a previous step failed
2020/06/05 03:46:21 Skipping step because a previous step failed
2020/06/05 03:46:21 Skipping step because a previous step failed
2020/06/05 03:46:22 Skipping step because a previous step failed
```

I will track it, once ruby is ready, then we can bring ruby test back.