### PR TITLE
Reuse generated service account

### DIFF
--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 			})
 
 			It("fails on creation due to missing namespaced buildstrategy", func() {
-				// override the Build to use a namespaced BuildStragegy
+				// override the Build to use a namespaced BuildStrategy
 				buildSample = ctl.DefaultBuild(buildName, strategyName, build.NamespacedBuildStrategyKind)
 
 				// Override Stub get calls to include a service account
@@ -199,7 +199,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 			})
 
 			It("fails on creation due to missing cluster buildstrategy", func() {
-				// override the Build to use a cluster BuildStragegy
+				// override the Build to use a cluster BuildStrategy
 				buildSample = ctl.DefaultBuild(buildName, strategyName, build.ClusterBuildStrategyKind)
 
 				// Override Stub get calls to include a service account
@@ -215,8 +215,54 @@ var _ = Describe("Reconcile BuildRun", func() {
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(" \"%s\" not found", strategyName)))
 			})
 
+			It("only generates the service account once if the task run cannot be created", func() {
+				// override the Build to use a cluster BuildStrategy
+				buildSample = ctl.DefaultBuild(buildName, strategyName, build.ClusterBuildStrategyKind)
+
+				// override buildrun to use a generated service account
+				buildRunName = "foobar-buildrun-sa-generate"
+				buildRunSample = ctl.BuildRunWithSAGenerate(buildRunName, buildName)
+				buildRunSample.Labels = make(map[string]string)
+				buildRunSample.Labels[build.LabelBuild] = buildName
+
+				// Override stub calls to include only build and buildrun
+				client.GetCalls(ctl.StubBuildRunGetWithoutSA(buildSample, buildRunSample))
+
+				// Call the reconciler
+				_, err := reconciler.Reconcile(request)
+
+				// Expect an error stating that the strategy does not exist
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(" \"%s\" not found", strategyName)))
+
+				// Expect one create call (service account)
+				Expect(client.CreateCallCount()).To(Equal(1))
+				_, obj, _ := client.CreateArgsForCall(0)
+				serviceAccount, castSuccessful := obj.(*corev1.ServiceAccount)
+				Expect(castSuccessful).To(BeTrue())
+
+				// Expect zero update calls
+				Expect(client.UpdateCallCount()).To(Equal(0))
+
+				// Change the Get stub to also return the service account
+				client.GetCalls(ctl.StubBuildRunGetWithSA(buildSample, buildRunSample, serviceAccount))
+
+				// Call the reconciler again
+				_, err = reconciler.Reconcile(request)
+
+				// Expect an error stating that the strategy does not exist
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(" \"%s\" not found", strategyName)))
+
+				// Expect no more create call because service account already existed
+				Expect(client.CreateCallCount()).To(Equal(1))
+
+				// Expect zero update calls because service account already existed and did not need to be modified
+				Expect(client.UpdateCallCount()).To(Equal(0))
+			})
+
 			It("fails on creation due to owner references errors", func() {
-				// override the Build to use a namespaced BuildStragegy
+				// override the Build to use a namespaced BuildStrategy
 				buildSample = ctl.DefaultBuild(buildName, strategyName, build.NamespacedBuildStrategyKind)
 
 				// Override Stub get calls to include a service account
@@ -239,7 +285,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 			})
 
 			It("succeed creating a task from a namespaced buildstrategy", func() {
-				// override the Build to use a namespaced BuildStragegy
+				// override the Build to use a namespaced BuildStrategy
 				buildSample = ctl.DefaultBuild(buildName, strategyName, build.NamespacedBuildStrategyKind)
 
 				// Override Stub get calls to include a service account
@@ -266,7 +312,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 			})
 
 			It("succeed creating a task from a cluster buildstrategy", func() {
-				// override the Build to use a cluster BuildStragegy
+				// override the Build to use a cluster BuildStrategy
 				buildSample = ctl.DefaultBuild(buildName, strategyName, build.ClusterBuildStrategyKind)
 
 				// Override Stub get calls to include a service account

--- a/pkg/controller/buildrun/credentials_test.go
+++ b/pkg/controller/buildrun/credentials_test.go
@@ -59,8 +59,10 @@ var _ = Describe("Credentials", func() {
 		})
 
 		It("adds the credentials to the service account", func() {
-			afterServiceAccount := buildRunController.ApplyCredentials(build, beforeServiceAccount)
+			afterServiceAccount := beforeServiceAccount.DeepCopy()
+			modified := buildRunController.ApplyCredentials(build, afterServiceAccount)
 
+			Expect(modified).To(BeTrue())
 			Expect(afterServiceAccount).To(Equal(expectedAfterServiceAccount))
 		})
 	})
@@ -73,7 +75,7 @@ var _ = Describe("Credentials", func() {
 					Source: buildv1alpha1.GitSource{
 						URL: "a/b/c",
 						SecretRef: &corev1.LocalObjectReference{
-							Name: "secret_a",
+							Name: "secret_b",
 						},
 					},
 				},
@@ -83,8 +85,10 @@ var _ = Describe("Credentials", func() {
 		})
 
 		It("keeps the service account unchanged", func() {
-			afterServiceAccount := buildRunController.ApplyCredentials(build, beforeServiceAccount)
+			afterServiceAccount := beforeServiceAccount.DeepCopy()
+			modified := buildRunController.ApplyCredentials(build, afterServiceAccount)
 
+			Expect(modified).To(BeFalse())
 			Expect(afterServiceAccount).To(Equal(expectedAfterServiceAccount))
 		})
 	})
@@ -105,8 +109,10 @@ var _ = Describe("Credentials", func() {
 		})
 
 		It("keeps the service account unchanged", func() {
-			afterServiceAccount := buildRunController.ApplyCredentials(build, beforeServiceAccount)
+			afterServiceAccount := beforeServiceAccount.DeepCopy()
+			modified := buildRunController.ApplyCredentials(build, afterServiceAccount)
 
+			Expect(modified).To(BeFalse())
 			Expect(afterServiceAccount).To(Equal(expectedAfterServiceAccount))
 		})
 	})

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -258,6 +258,25 @@ func (c *Catalog) StubBuildRunLabel(buildSample *build.Build) func(context conte
 	}
 }
 
+// StubBuildRunGetWithoutSA simulates the output of client GET calls
+// for the BuildRun unit tests
+func (c *Catalog) StubBuildRunGetWithoutSA(
+	b *build.Build,
+	br *build.BuildRun,
+) func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
+	return func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
+		switch object := object.(type) {
+		case *build.Build:
+			b.DeepCopyInto(object)
+			return nil
+		case *build.BuildRun:
+			br.DeepCopyInto(object)
+			return nil
+		}
+		return errors.NewNotFound(schema.GroupResource{}, nn.Name)
+	}
+}
+
 // StubBuildRunGetWithSA simulates the output of client GET calls
 // for the BuildRun unit tests
 func (c *Catalog) StubBuildRunGetWithSA(
@@ -411,6 +430,24 @@ func (c *Catalog) BuildRunWithSA(buildRunName string, buildName string, saName s
 			ServiceAccount: &build.ServiceAccount{
 				Name:     &saName,
 				Generate: false,
+			},
+		},
+	}
+}
+
+// BuildRunWithSA returns a customized BuildRun object that defines a
+// service account
+func (c *Catalog) BuildRunWithSAGenerate(buildRunName string, buildName string) *build.BuildRun {
+	return &build.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: buildRunName,
+		},
+		Spec: build.BuildRunSpec{
+			BuildRef: &build.BuildRef{
+				Name: buildName,
+			},
+			ServiceAccount: &build.ServiceAccount{
+				Generate: true,
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #203 

The pull request changes the code in the BuildRun controller's `retrieveServiceAccount` function to do a `CreateOrUpdate` to create the service account. This fixes the issue of a reconciliation successfully creating the service account but failing to create the task run. The following reconciliation then tried to create the service account again and failed.

I added a temporary error into the buildrun controller to test my fix. The first buildrun reconcile leads to this log message:

```log
{"level":"info","ts":1591343891.9695,"logger":"controller_buildrun","msg":"Automatic generation of service account","ServiceAccount":"kaniko-timeout-sa","Operation":"created"}
```

Further reconciles look like this (note the operation returned by `CreateOrUpdate` is `unchanged`):

```log
{"level":"info","ts":1591343892.983816,"logger":"controller_buildrun","msg":"Automatic generation of service account","ServiceAccount":"kaniko-timeout-sa","Operation":"unchanged"}
```

-- 

While implementing the code I noticed a problem with the `ApplyCredentials` function. It was defined to take a reference of a ServiceAccount but also returned one. Its implementation only modified the passed ServiceAccount and returned it. The unit tests where assuming that a copy is returned. This lead to one test case to pass instead of to fail (the test case was not correct). I changed the code of the `ApplyCredentials` function to not return the ServiceAccount anymore to prevent that confusion. Instead, it is returning a `bool` now to indicate whether the service account was modified. I am using this to only call `client.Update` if it was really modified.