### PR TITLE
Support Ginkgo flakeAttempts flag

### DIFF
--- a/HACK.md
+++ b/HACK.md
@@ -74,13 +74,13 @@ make test
 
 The following table contains a set of environment variables that control the behavior of the e2e tests.
 
-| Environment Variable            | Default                                                                         | Description                                                   |
-|---------------------------------|---------------------------------------------------------------------------------|---------------------------------------------------------------|
-| `TEST_NAMESPACE`                | `default`                                                                       | Target namespace to execute tests upon, default is `default`. |
-| `TEST_E2E_FLAGS`                | `-failFast -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=15m -trace -v` | Ginkgo flags. See all Ginkgo flags here: [The Ginkgo CLI](https://onsi.github.io/ginkgo/#the-ginkgo-cli). Especially of interest are `--focus` and `--skip` to run selective tests. |
-| `TEST_E2E_CREATE_GLOBALOBJECTS` | `true`                                                                          | Boolean, if `false`, the custom resource definitions and (cluster) build strategies are not created and deleted by the e2e test code |
-| `TEST_E2E_OPERATOR`             | `start_local`                                                                   | String with allowed values `start_local` (will start the local operator and print its logs add the end of the test run) and `managed_outside` (will assume that the operator is running through whatever means) |
-| `TEST_E2E_VERIFY_TEKTONOBJECTS` | `true`                                                                          | Boolean, if false, the verification code will not try to verify the TaskRun object status |
+| Environment Variable            | Default                                                                                          | Description                                                   |
+|---------------------------------|--------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| `TEST_NAMESPACE`                | `default`                                                                                        | Target namespace to execute tests upon, default is `default`. |
+| `TEST_E2E_FLAGS`                | `-failFast -flakeAttempts=2 -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=20m -trace -v` | Ginkgo flags. See all Ginkgo flags here: [The Ginkgo CLI](https://onsi.github.io/ginkgo/#the-ginkgo-cli). Especially of interest are `--focus` and `--skip` to run selective tests. |
+| `TEST_E2E_CREATE_GLOBALOBJECTS` | `true`                                                                                           | Boolean, if `false`, the custom resource definitions and (cluster) build strategies are not created and deleted by the e2e test code |
+| `TEST_E2E_OPERATOR`             | `start_local`                                                                                    | String with allowed values `start_local` (will start the local operator and print its logs add the end of the test run) and `managed_outside` (will assume that the operator is running through whatever means) |
+| `TEST_E2E_VERIFY_TEKTONOBJECTS` | `true`                                                                                           | Boolean, if false, the verification code will not try to verify the TaskRun object status |
 
 The following table contains a list of environment variables you that will override specific paths under the **Build** CRD.
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ TEKTON_VERSION ?= v0.11.3
 SDK_VERSION ?= v0.17.0
 
 # E2E test flags
-TEST_E2E_FLAGS ?= -failFast -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=20m -trace -v
+TEST_E2E_FLAGS ?= -failFast -flakeAttempts=2 -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=20m -trace -v
 
 # E2E test operator behavior, can be start_local or managed_outside
 TEST_E2E_OPERATOR ?= start_local

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -11,6 +11,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 	var (
 		namespace string
+		testId    string
 	)
 
 	BeforeEach(func() {
@@ -22,19 +23,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Buildah build is defined", func() {
 
 		BeforeEach(func() {
+			testId = generateTestID("buildah")
+
 			// create the build definition
-			createBuild(namespace, "buildah", "samples/build/build_buildah_cr.yaml")
+			createBuild(namespace, testId, "samples/build/build_buildah_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildah")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, "buildah", "samples/buildrun/buildrun_buildah_cr.yaml")
+			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildah_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -44,38 +47,46 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Buildah build with a contextDir and a custom Dockerfile name is defined", func() {
 
 		BeforeEach(func() {
+			testId = generateTestID("buildah-custom-context-dockerfile")
+
 			// create the build definition
-			createBuild(namespace, "buildah-custom-context-dockerfile", "test/data/build_buildah_cr_custom_context+dockerfile.yaml")
+			createBuild(namespace, testId, "test/data/build_buildah_cr_custom_context+dockerfile.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildah-custom-context-dockerfile")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, "buildah-custom-context-dockerfile", "test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml")
+			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
-			validateBuildDeletion(namespace, "buildah-custom-context-dockerfile", br, false)
+			validateBuildDeletion(namespace, testId, br, false)
 		})
 	})
 
 	Context("when a heroku Buildpacks build is defined using a cluster strategy", func() {
 
+		BeforeEach(func() {
+			testId = generateTestID("buildpacks-v3-heroku")
+
+			// create the build definition
+			createBuild(namespace, testId, "samples/build/build_buildpacks-v3-heroku_cr.yaml")
+		})
+
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-heroku")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			createBuild(namespace, "buildpacks-v3-heroku", "samples/build/build_buildpacks-v3-heroku_cr.yaml")
-			br, err := buildRunTestData(namespace, "buildpacks-v3-heroku", "samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml")
+			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -84,16 +95,22 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 	Context("when a heroku Buildpacks build is defined using a namespaced strategy", func() {
 
+		BeforeEach(func() {
+			testId = generateTestID("buildpacks-v3-heroku-namespaced")
+
+			// create the build definition
+			createBuild(namespace, testId, "samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml")
+		})
+
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-heroku-namespaced")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			createBuild(namespace, "buildpacks-v3-heroku-namespaced", "samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml")
-			br, err := buildRunTestData(namespace, "buildpacks-v3-heroku-namespaced", "samples/buildrun/buildrun_buildpacks-v3-heroku_namespaced_cr.yaml")
+			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildpacks-v3-heroku_namespaced_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -102,35 +119,47 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 	Context("when a Buildpacks v3 build is defined using a cluster strategy", func() {
 
+		BeforeEach(func() {
+			testId = generateTestID("buildpacks-v3")
+
+			// create the build definition
+			createBuild(namespace, testId, "samples/build/build_buildpacks-v3_cr.yaml")
+		})
+
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
-		It("successfully runs with a cluster scope strategy", func() {
-			createBuild(namespace, "buildpacks-v3", "samples/build/build_buildpacks-v3_cr.yaml")
-			br, err := buildRunTestData(namespace, "buildpacks-v3", "samples/buildrun/buildrun_buildpacks-v3_cr.yaml")
+		It("successfully runs a build", func() {
+			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildpacks-v3_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
-			validateBuildDeletion(namespace, "buildpacks-v3", br, false)
+			validateBuildDeletion(namespace, testId, br, false)
 		})
 	})
 
 	Context("when a Buildpacks v3 build is defined using a namespaced strategy", func() {
 
+		BeforeEach(func() {
+			testId = generateTestID("buildpacks-v3-namespaced")
+
+			// create the build definition
+			createBuild(namespace, testId, "samples/build/build_buildpacks-v3_namespaced_cr.yaml")
+		})
+
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-namespaced")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			createBuild(namespace, "buildpacks-v3-namespaced", "samples/build/build_buildpacks-v3_namespaced_cr.yaml")
-			br, err := buildRunTestData(namespace, "buildpacks-v3-namespaced", "samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml")
+			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -139,16 +168,22 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 	Context("when a Buildpacks v3 build is defined for a php runtime", func() {
 
+		BeforeEach(func() {
+			testId = generateTestID("buildpacks-v3-php")
+
+			// create the build definition
+			createBuild(namespace, testId, "test/data/build_buildpacks-v3_php_cr.yaml")
+		})
+
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-php")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			createBuild(namespace, "buildpacks-v3-php", "test/data/build_buildpacks-v3_php_cr.yaml")
-			br, err := buildRunTestData(namespace, "buildpacks-v3-php", "test/data/buildrun_buildpacks-v3_php_cr.yaml")
+			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_buildpacks-v3_php_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -160,18 +195,22 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		BeforeEach(func() {
 			// issue track in paketo side: https://github.com/paketo-community/ruby/issues/59
 			Skip("Skipping test case because Ruby support in paketo is still under development.")
+
+			testId = generateTestID("buildpacks-v3-ruby")
+
+			// create the build definition
+			createBuild(namespace, testId, "test/data/build_buildpacks-v3_ruby_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-ruby")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			createBuild(namespace, "buildpacks-v3-ruby", "test/data/build_buildpacks-v3_ruby_cr.yaml")
-			br, err := buildRunTestData(namespace, "buildpacks-v3-ruby", "test/data/buildrun_buildpacks-v3_ruby_cr.yaml")
+			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_buildpacks-v3_ruby_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -180,16 +219,22 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 	Context("when a Buildpacks v3 build is defined for a golang runtime", func() {
 
+		BeforeEach(func() {
+			testId = generateTestID("buildpacks-v3-golang")
+
+			// create the build definition
+			createBuild(namespace, testId, "test/data/build_buildpacks-v3_golang_cr.yaml")
+		})
+
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-golang")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			createBuild(namespace, "buildpacks-v3-golang", "test/data/build_buildpacks-v3_golang_cr.yaml")
-			br, err := buildRunTestData(namespace, "buildpacks-v3-golang", "test/data/buildrun_buildpacks-v3_golang_cr.yaml")
+			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_buildpacks-v3_golang_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -198,16 +243,22 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 	Context("when a Buildpacks v3 build is defined for a java runtime", func() {
 
+		BeforeEach(func() {
+			testId = generateTestID("buildpacks-v3-java")
+
+			// create the build definition
+			createBuild(namespace, testId, "test/data/build_buildpacks-v3_java_cr.yaml")
+		})
+
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "buildpacks-v3-java")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			createBuild(namespace, "buildpacks-v3-java", "test/data/build_buildpacks-v3_java_cr.yaml")
-			br, err := buildRunTestData(namespace, "buildpacks-v3-java", "test/data/buildrun_buildpacks-v3_java_cr.yaml")
+			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_buildpacks-v3_java_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -217,42 +268,46 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Kaniko build is defined", func() {
 
 		BeforeEach(func() {
+			testId = generateTestID("kaniko")
+
 			// create the build definition
-			createBuild(namespace, "kaniko", "samples/build/build_kaniko_cr.yaml")
+			createBuild(namespace, testId, "samples/build/build_kaniko_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "kaniko")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, "kaniko", "samples/buildrun/buildrun_kaniko_cr.yaml")
+			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_kaniko_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
-			validateBuildDeletion(namespace, "kaniko", br, true)
+			validateBuildDeletion(namespace, testId, br, true)
 		})
 	})
 
 	Context("when a Kaniko build with a Dockerfile that requires advanced permissions is defined", func() {
 
 		BeforeEach(func() {
+			testId = generateTestID("kaniko-advanced-dockerfile")
+
 			// create the build definition
-			createBuild(namespace, "kaniko-advanced-dockerfile", "test/data/build_kaniko_cr_advanced_dockerfile.yaml")
+			createBuild(namespace, testId, "test/data/build_kaniko_cr_advanced_dockerfile.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "kaniko-advanced-dockerfile")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, "kaniko-advanced-dockerfile", "test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml")
+			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -262,19 +317,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Kaniko build with a contextDir and a custom Dockerfile name is defined", func() {
 
 		BeforeEach(func() {
+			testId = generateTestID("kaniko-custom-context-dockerfile")
+
 			// create the build definition
-			createBuild(namespace, "kaniko-custom-context-dockerfile", "test/data/build_kaniko_cr_custom_context+dockerfile.yaml")
+			createBuild(namespace, testId, "test/data/build_kaniko_cr_custom_context+dockerfile.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "kaniko-custom-context-dockerfile")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, "kaniko-custom-context-dockerfile", "test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml")
+			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -284,19 +341,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Kaniko build with a short timeout is defined", func() {
 
 		BeforeEach(func() {
+			testId = generateTestID("kaniko-timeout")
+
 			// create the build definition
-			createBuild(namespace, "kaniko-timeout", "test/data/build_timeout.yaml")
+			createBuild(namespace, testId, "test/data/build_timeout.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "kaniko-timeout")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("fails the build run", func() {
-			br, err := buildRunTestData(namespace, "kaniko-timeout", "test/data/buildrun_timeout.yaml")
+			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_timeout.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToFail(namespace, br, "kaniko-timeout.*failed to finish within \"15s\"")
@@ -306,19 +365,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a s2i build is defined", func() {
 
 		BeforeEach(func() {
+			testId = generateTestID("s2i")
+
 			// create the build definition
-			createBuild(namespace, "s2i", "samples/build/build_source-to-image_cr.yaml")
+			createBuild(namespace, testId, "samples/build/build_source-to-image_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, "s2i")
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, "s2i", "samples/buildrun/buildrun_source-to-image_cr.yaml")
+			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_source-to-image_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -336,19 +397,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		Context("when a Buildah build is defined to use a private GitHub repository", func() {
 
 			BeforeEach(func() {
+				testId = generateTestID("private-github-buildah")
+
 				// create the build definition
-				createBuild(namespace, "private-github-buildah", "test/data/build_buildah_cr_private_github.yaml")
+				createBuild(namespace, testId, "test/data/build_buildah_cr_private_github.yaml")
 			})
 
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					outputBuildAndBuildRunStatusAndPodLogs(namespace, "private-github-buildah")
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 				}
 			})
 
 			It("successfully runs a build", func() {
-				br, err := buildRunTestData(namespace, "private-github-buildah", "samples/buildrun/buildrun_buildah_cr.yaml")
+				br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildah_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
 				validateBuildRunToSucceed(namespace, br)
@@ -358,19 +421,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		Context("when a Buildah build is defined to use a private GitLab repository", func() {
 
 			BeforeEach(func() {
+				testId = generateTestID("private-gitlab-buildah")
+
 				// create the build definition
-				createBuild(namespace, "private-gitlab-buildah", "test/data/build_buildah_cr_private_gitlab.yaml")
+				createBuild(namespace, testId, "test/data/build_buildah_cr_private_gitlab.yaml")
 			})
 
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					outputBuildAndBuildRunStatusAndPodLogs(namespace, "private-gitlab-buildah")
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 				}
 			})
 
 			It("successfully runs a build", func() {
-				br, err := buildRunTestData(namespace, "private-gitlab-buildah", "samples/buildrun/buildrun_buildah_cr.yaml")
+				br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildah_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
 				validateBuildRunToSucceed(namespace, br)
@@ -380,19 +445,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		Context("when a Kaniko build is defined to use a private GitHub repository", func() {
 
 			BeforeEach(func() {
+				testId = generateTestID("private-github-kaniko")
+
 				// create the build definition
-				createBuild(namespace, "private-github-kaniko", "test/data/build_kaniko_cr_private_github.yaml")
+				createBuild(namespace, testId, "test/data/build_kaniko_cr_private_github.yaml")
 			})
 
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					outputBuildAndBuildRunStatusAndPodLogs(namespace, "private-github-kaniko")
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 				}
 			})
 
 			It("successfully runs a build", func() {
-				br, err := buildRunTestData(namespace, "private-github-kaniko", "samples/buildrun/buildrun_kaniko_cr.yaml")
+				br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_kaniko_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
 				validateBuildRunToSucceed(namespace, br)
@@ -402,19 +469,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		Context("when a Kaniko build is defined to use a private GitLab repository", func() {
 
 			BeforeEach(func() {
+				testId = generateTestID("private-gitlab-kaniko")
+
 				// create the build definition
-				createBuild(namespace, "private-gitlab-kaniko", "test/data/build_kaniko_cr_private_gitlab.yaml")
+				createBuild(namespace, testId, "test/data/build_kaniko_cr_private_gitlab.yaml")
 			})
 
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					outputBuildAndBuildRunStatusAndPodLogs(namespace, "private-gitlab-kaniko")
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 				}
 			})
 
 			It("successfully runs a build", func() {
-				br, err := buildRunTestData(namespace, "private-gitlab-kaniko", "samples/buildrun/buildrun_kaniko_cr.yaml")
+				br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_kaniko_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
 				validateBuildRunToSucceed(namespace, br)
@@ -424,19 +493,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		Context("when a s2i build is defined to use a private GitHub repository", func() {
 
 			BeforeEach(func() {
+				testId = generateTestID("private-github-s2i")
+
 				// create the build definition
-				createBuild(namespace, "private-github-s2i", "test/data/build_source-to-image_cr_private_github.yaml")
+				createBuild(namespace, testId, "test/data/build_source-to-image_cr_private_github.yaml")
 			})
 
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					outputBuildAndBuildRunStatusAndPodLogs(namespace, "private-github-s2i")
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
 				}
 			})
 
 			It("successfully runs a build", func() {
-				br, err := buildRunTestData(namespace, "private-github-s2i", "samples/buildrun/buildrun_source-to-image_cr.yaml")
+				br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_source-to-image_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
 				validateBuildRunToSucceed(namespace, br)

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -412,6 +412,7 @@ k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/strategicpatch


### PR DESCRIPTION
Tests are supposed to be stable. We are not seeing this with our e2e tests. The problem is that we do not have everything under our control. We rely on external resources like the git repositories and the container registry. In addition, specifically in the Travis environment here, we are seeing instabilities that we do not see elsewhere.

I am therefore adding support for Ginkgo's `flakeAttempts` flag to the e2e tests. It was so far not possible to just set the flag because each test case creates a build and build run with a constant name. On a retry of a specific test case, the recreation of those artifacts failed because of the unique name constraint.