### PR TITLE
Allow fast fail when a travis job failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ services:
 install:
   - make travis
 script:
+  - set -e
   - make
   # https://github.com/redhat-developer/build/issues/123
   - make test-unit-coverage
   - make test-e2e TEST_IMAGE_REPO="$(./hack/install-registry.sh show):5000/redhat-developer/build-e2e"
+  - set +e


### PR DESCRIPTION
Fix issue: https://github.com/redhat-developer/build/issues/241

We need to allow fast fail when a job failed in travis.

Related discussion on travis side: https://github.com/travis-ci/travis-ci/issues/1066

Look like, there is no a travis key can be used to set fast fail mode. So I refer to [this comment](https://github.com/travis-ci/travis-ci/issues/1066#issuecomment-32415710) and [this one](https://github.com/travis-ci/travis-ci/issues/1066#issuecomment-479594195) to make our travis can be exited right away once a travis job failed.