### PR TITLE
Delete generated service account on end of the build run

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"os"
 
+	operator "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -10,34 +12,43 @@ import (
 var _ = Describe("For a Kubernetes cluster with Tekton and build installed", func() {
 
 	var (
+		br        *operator.BuildRun
+		err       error
 		namespace string
-		testId    string
+		testID    string
 	)
 
 	BeforeEach(func() {
-		ns, err := ctx.GetWatchNamespace()
+		br = nil
+
+		namespace, err = ctx.GetWatchNamespace()
 		Expect(err).ToNot(HaveOccurred())
-		namespace = ns
+	})
+
+	AfterEach(func() {
+		if br != nil {
+			validateServiceAccountDeletion(br, namespace)
+		}
 	})
 
 	Context("when a Buildah build is defined", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("buildah")
+			testID = generateTestID("buildah")
 
 			// create the build definition
-			createBuild(namespace, testId, "samples/build/build_buildah_cr.yaml")
+			createBuild(namespace, testID, "samples/build/build_buildah_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildah_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildah_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -47,46 +58,46 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Buildah build with a contextDir and a custom Dockerfile name is defined", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("buildah-custom-context-dockerfile")
+			testID = generateTestID("buildah-custom-context-dockerfile")
 
 			// create the build definition
-			createBuild(namespace, testId, "test/data/build_buildah_cr_custom_context+dockerfile.yaml")
+			createBuild(namespace, testID, "test/data/build_buildah_cr_custom_context+dockerfile.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml")
+			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
-			validateBuildDeletion(namespace, testId, br, false)
+			validateBuildDeletion(namespace, testID, br, false)
 		})
 	})
 
 	Context("when a heroku Buildpacks build is defined using a cluster strategy", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("buildpacks-v3-heroku")
+			testID = generateTestID("buildpacks-v3-heroku")
 
 			// create the build definition
-			createBuild(namespace, testId, "samples/build/build_buildpacks-v3-heroku_cr.yaml")
+			createBuild(namespace, testID, "samples/build/build_buildpacks-v3-heroku_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -96,21 +107,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a heroku Buildpacks build is defined using a namespaced strategy", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("buildpacks-v3-heroku-namespaced")
+			testID = generateTestID("buildpacks-v3-heroku-namespaced")
 
 			// create the build definition
-			createBuild(namespace, testId, "samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml")
+			createBuild(namespace, testID, "samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildpacks-v3-heroku_namespaced_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3-heroku_namespaced_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -120,46 +131,46 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Buildpacks v3 build is defined using a cluster strategy", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("buildpacks-v3")
+			testID = generateTestID("buildpacks-v3")
 
 			// create the build definition
-			createBuild(namespace, testId, "samples/build/build_buildpacks-v3_cr.yaml")
+			createBuild(namespace, testID, "samples/build/build_buildpacks-v3_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildpacks-v3_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
-			validateBuildDeletion(namespace, testId, br, false)
+			validateBuildDeletion(namespace, testID, br, false)
 		})
 	})
 
 	Context("when a Buildpacks v3 build is defined using a namespaced strategy", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("buildpacks-v3-namespaced")
+			testID = generateTestID("buildpacks-v3-namespaced")
 
 			// create the build definition
-			createBuild(namespace, testId, "samples/build/build_buildpacks-v3_namespaced_cr.yaml")
+			createBuild(namespace, testID, "samples/build/build_buildpacks-v3_namespaced_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -169,21 +180,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Buildpacks v3 build is defined for a php runtime", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("buildpacks-v3-php")
+			testID = generateTestID("buildpacks-v3-php")
 
 			// create the build definition
-			createBuild(namespace, testId, "test/data/build_buildpacks-v3_php_cr.yaml")
+			createBuild(namespace, testID, "test/data/build_buildpacks-v3_php_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_buildpacks-v3_php_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_php_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -196,21 +207,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			// issue track in paketo side: https://github.com/paketo-community/ruby/issues/59
 			Skip("Skipping test case because Ruby support in paketo is still under development.")
 
-			testId = generateTestID("buildpacks-v3-ruby")
+			testID = generateTestID("buildpacks-v3-ruby")
 
 			// create the build definition
-			createBuild(namespace, testId, "test/data/build_buildpacks-v3_ruby_cr.yaml")
+			createBuild(namespace, testID, "test/data/build_buildpacks-v3_ruby_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_buildpacks-v3_ruby_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_ruby_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -220,21 +231,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Buildpacks v3 build is defined for a golang runtime", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("buildpacks-v3-golang")
+			testID = generateTestID("buildpacks-v3-golang")
 
 			// create the build definition
-			createBuild(namespace, testId, "test/data/build_buildpacks-v3_golang_cr.yaml")
+			createBuild(namespace, testID, "test/data/build_buildpacks-v3_golang_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_buildpacks-v3_golang_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_golang_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -244,21 +255,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Buildpacks v3 build is defined for a java runtime", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("buildpacks-v3-java")
+			testID = generateTestID("buildpacks-v3-java")
 
 			// create the build definition
-			createBuild(namespace, testId, "test/data/build_buildpacks-v3_java_cr.yaml")
+			createBuild(namespace, testID, "test/data/build_buildpacks-v3_java_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_buildpacks-v3_java_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_java_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -268,46 +279,46 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Kaniko build is defined", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("kaniko")
+			testID = generateTestID("kaniko")
 
 			// create the build definition
-			createBuild(namespace, testId, "samples/build/build_kaniko_cr.yaml")
+			createBuild(namespace, testID, "samples/build/build_kaniko_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_kaniko_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_kaniko_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
-			validateBuildDeletion(namespace, testId, br, true)
+			validateBuildDeletion(namespace, testID, br, true)
 		})
 	})
 
 	Context("when a Kaniko build with a Dockerfile that requires advanced permissions is defined", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("kaniko-advanced-dockerfile")
+			testID = generateTestID("kaniko-advanced-dockerfile")
 
 			// create the build definition
-			createBuild(namespace, testId, "test/data/build_kaniko_cr_advanced_dockerfile.yaml")
+			createBuild(namespace, testID, "test/data/build_kaniko_cr_advanced_dockerfile.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml")
+			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -317,21 +328,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Kaniko build with a contextDir and a custom Dockerfile name is defined", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("kaniko-custom-context-dockerfile")
+			testID = generateTestID("kaniko-custom-context-dockerfile")
 
 			// create the build definition
-			createBuild(namespace, testId, "test/data/build_kaniko_cr_custom_context+dockerfile.yaml")
+			createBuild(namespace, testID, "test/data/build_kaniko_cr_custom_context+dockerfile.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml")
+			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -341,21 +352,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Kaniko build with a short timeout is defined", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("kaniko-timeout")
+			testID = generateTestID("kaniko-timeout")
 
 			// create the build definition
-			createBuild(namespace, testId, "test/data/build_timeout.yaml")
+			createBuild(namespace, testID, "test/data/build_timeout.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("fails the build run", func() {
-			br, err := buildRunTestData(namespace, testId, "test/data/buildrun_timeout.yaml")
+			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_timeout.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToFail(namespace, br, "kaniko-timeout.*failed to finish within \"15s\"")
@@ -365,21 +376,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a s2i build is defined", func() {
 
 		BeforeEach(func() {
-			testId = generateTestID("s2i")
+			testID = generateTestID("s2i")
 
 			// create the build definition
-			createBuild(namespace, testId, "samples/build/build_source-to-image_cr.yaml")
+			createBuild(namespace, testID, "samples/build/build_source-to-image_cr.yaml")
 		})
 
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				Logf("Print failed BuildRun's log")
-				outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+				outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 			}
 		})
 
 		It("successfully runs a build", func() {
-			br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_source-to-image_cr.yaml")
+			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_source-to-image_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(namespace, br)
@@ -397,21 +408,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		Context("when a Buildah build is defined to use a private GitHub repository", func() {
 
 			BeforeEach(func() {
-				testId = generateTestID("private-github-buildah")
+				testID = generateTestID("private-github-buildah")
 
 				// create the build definition
-				createBuild(namespace, testId, "test/data/build_buildah_cr_private_github.yaml")
+				createBuild(namespace, testID, "test/data/build_buildah_cr_private_github.yaml")
 			})
 
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 				}
 			})
 
 			It("successfully runs a build", func() {
-				br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildah_cr.yaml")
+				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildah_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
 				validateBuildRunToSucceed(namespace, br)
@@ -421,21 +432,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		Context("when a Buildah build is defined to use a private GitLab repository", func() {
 
 			BeforeEach(func() {
-				testId = generateTestID("private-gitlab-buildah")
+				testID = generateTestID("private-gitlab-buildah")
 
 				// create the build definition
-				createBuild(namespace, testId, "test/data/build_buildah_cr_private_gitlab.yaml")
+				createBuild(namespace, testID, "test/data/build_buildah_cr_private_gitlab.yaml")
 			})
 
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 				}
 			})
 
 			It("successfully runs a build", func() {
-				br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_buildah_cr.yaml")
+				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildah_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
 				validateBuildRunToSucceed(namespace, br)
@@ -445,21 +456,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		Context("when a Kaniko build is defined to use a private GitHub repository", func() {
 
 			BeforeEach(func() {
-				testId = generateTestID("private-github-kaniko")
+				testID = generateTestID("private-github-kaniko")
 
 				// create the build definition
-				createBuild(namespace, testId, "test/data/build_kaniko_cr_private_github.yaml")
+				createBuild(namespace, testID, "test/data/build_kaniko_cr_private_github.yaml")
 			})
 
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 				}
 			})
 
 			It("successfully runs a build", func() {
-				br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_kaniko_cr.yaml")
+				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_kaniko_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
 				validateBuildRunToSucceed(namespace, br)
@@ -469,21 +480,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		Context("when a Kaniko build is defined to use a private GitLab repository", func() {
 
 			BeforeEach(func() {
-				testId = generateTestID("private-gitlab-kaniko")
+				testID = generateTestID("private-gitlab-kaniko")
 
 				// create the build definition
-				createBuild(namespace, testId, "test/data/build_kaniko_cr_private_gitlab.yaml")
+				createBuild(namespace, testID, "test/data/build_kaniko_cr_private_gitlab.yaml")
 			})
 
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 				}
 			})
 
 			It("successfully runs a build", func() {
-				br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_kaniko_cr.yaml")
+				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_kaniko_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
 				validateBuildRunToSucceed(namespace, br)
@@ -493,21 +504,21 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		Context("when a s2i build is defined to use a private GitHub repository", func() {
 
 			BeforeEach(func() {
-				testId = generateTestID("private-github-s2i")
+				testID = generateTestID("private-github-s2i")
 
 				// create the build definition
-				createBuild(namespace, testId, "test/data/build_source-to-image_cr_private_github.yaml")
+				createBuild(namespace, testID, "test/data/build_source-to-image_cr_private_github.yaml")
 			})
 
 			AfterEach(func() {
 				if CurrentGinkgoTestDescription().Failed {
 					Logf("Print failed BuildRun's log")
-					outputBuildAndBuildRunStatusAndPodLogs(namespace, testId)
+					outputBuildAndBuildRunStatusAndPodLogs(namespace, testID)
 				}
 			})
 
 			It("successfully runs a build", func() {
-				br, err := buildRunTestData(namespace, testId, "samples/buildrun/buildrun_source-to-image_cr.yaml")
+				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_source-to-image_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
 				validateBuildRunToSucceed(namespace, br)


### PR DESCRIPTION
Fixes #264

Adding logic to the build run controller that automatically deletes the generated services account on finish of the buildrun. I'd like to have feedback on https://github.com/SaschaSchwarze0/build/blob/sascha-264-delete-generated-sa/pkg/controller/buildrun/buildrun_controller.go#L174-L177 where I decided to ignore an error during the service account deletion.

The e2e test change looks massive, so let me explain it here: I added a function `validateServiceAccountDeletion` that runs after every test case and validates that the generated service account was deleted depending on the buildrun status. For this, I had to move the the declaration of the `br`and `err` variables. The rename from `testId` to `testID` is a go-lint suggestion.