### PR TITLE
Upgrade to latest Kaniko version with workaround for AWS client delay

### DIFF
--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v0.19.0
+      image: gcr.io/kaniko-project/executor:v0.23.0
       workingdir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -20,6 +20,10 @@ spec:
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
+        - name: AWS_ACCESS_KEY_ID
+          value: NOT_SET
+        - name: AWS_SECRET_KEY
+          value: NOT_SET
       command:
         - /kaniko/executor
       args:


### PR DESCRIPTION
Fixes #266

Let me explain what I am doing here. With kaniko 0.20, changes got introduced that I started to outline here: https://github.com/redhat-developer/build/issues/238#issue-628325976. Further details are that Ffom Kaniko 0.19 to 0.20 there was commit https://github.com/GoogleContainerTools/kaniko/commit/7b51aec5d955e9bc642943a4b8672575600782e7. It changes the dependency on github.com/google/go-containerregistry from v0.0.0-20191218175032-34fb8ff33bed to v0.0.0-20200313165449-955bf358a3d8.

In go-containerregistry, there is commit https://github.com/google/go-containerregistry/commit/a1fca010ae9cbeb2132652e304335b04f3368455. In this commit, the dependency on k8s.io/kubernetes (includes k8s.io/kubernetes/pkg/credentialprovider) v1.11.10 was removed. Instead a dependency on github.com/vdemeester/k8s-pkg-credentialprovider v0.0.0-20200107171650-7c61ffa44238 was added.

The whole reason of this does not matter so much for us, but this change also updated the k8s code (in the fork that is now used). And in this code, there is commit https://github.com/kubernetes/kubernetes/commit/11efc013288a15322a6abc0852a4859f7b0785dc. This commit changes `ecrProvider.Enabled()` form simply returning `true` to this code:

```go
func (p *ecrProvider) Enabled() bool {
	sess, err := session.NewSessionWithOptions(session.Options{
		SharedConfigState: session.SharedConfigEnable,
	})
	if err != nil {
		klog.Errorf("while validating AWS credentials %v", err)
		return false
	}
	if _, err := sess.Config.Credentials.Get(); err != nil {
		klog.Errorf("while getting AWS credentials %v", err)
		return false
	}
	return true
}
```

This code initializes the AWS SDK toolkit to verify if it can be used. This toolkit has a set of steps it performs to find AWS access keys. It looks at a config file at a fixed place, at a configurable place through env var, at env vars directly containing the keys. And if all did not help, it connects to http://169.254.169.254/latest/meta-data/iam/security-credentials/ to get the credentials. But this endpoint is EC2 specific as far as I understand it. In other k8s cluster this cannot be resolved and caused the 30 seconds timeout.

-- 

The code change now provides the two environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY` with SOME value. This causes the AWS SDK to determine that the credentials for AWS are set up and stops. The `Enabled` function then returns true again.

The interesting question now is whether we have to do something to allow pushing to [Amazon ECR](https://aws.amazon.com/ecr/), but I see this a separate issue. If something has to be done, then pushing to ECR did not work in the past and does not now. This Kaniko documentation suggests we have to do something: [Pushing to Amazon ECR](https://github.com/GoogleContainerTools/kaniko#pushing-to-amazon-ecr)