### PR TITLE
Adding some enhancements on the logging we define.

### DIFF
--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -121,7 +121,7 @@ func (r *ReconcileBuild) Reconcile(request reconcile.Request) (reconcile.Result,
 	if err != nil && !apierrors.IsNotFound(err) {
 		return reconcile.Result{}, err
 	} else if apierrors.IsNotFound(err) {
-		ctxlog.Debug(ctx, "finishing reconciling build. build was not found", namespace, request.Namespace, name, request.Name)
+		ctxlog.Debug(ctx, "finish reconciling build. build was not found", namespace, request.Namespace, name, request.Name)
 		return reconcile.Result{}, nil
 	}
 
@@ -151,8 +151,7 @@ func (r *ReconcileBuild) Reconcile(request reconcile.Request) (reconcile.Result,
 
 	// Validate if the build strategy is defined
 	if b.Spec.StrategyRef != nil {
-		err := r.validateStrategyRef(ctx, b.Spec.StrategyRef, b.Namespace)
-		if err != nil {
+		if err := r.validateStrategyRef(ctx, b.Spec.StrategyRef, b.Namespace); err != nil {
 			b.Status.Reason = err.Error()
 			updateErr := r.client.Status().Update(ctx, b)
 			return reconcile.Result{}, fmt.Errorf("errors: %v %v", err, updateErr)

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -324,7 +324,7 @@ func (r *ReconcileBuildRun) retrieveServiceAccount(ctx context.Context, build *b
 
 		// Add credentials and update the service account
 		if modified := ApplyCredentials(ctx, build, serviceAccount); modified {
-			ctxlog.Info(ctx, "update ServiceAccount with secrets from build", namespace, serviceAccount.Namespace, name, serviceAccount.Name)
+			ctxlog.Info(ctx, "updating ServiceAccount with secrets from build", namespace, serviceAccount.Namespace, name, serviceAccount.Name)
 			if err := r.client.Update(ctx, serviceAccount); err != nil {
 				return nil, err
 			}

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -28,6 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+const namespace string = "namespace"
+const name string = "name"
+
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
 * business logic.  Delete these comments after modifying this file.*
@@ -119,7 +122,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 	ctx, cancel := context.WithTimeout(r.ctx, r.config.CtxTimeOut)
 	defer cancel()
 
-	ctxlog.Info(ctx, "Reconciling BuildRun", "Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	ctxlog.Debug(ctx, "start reconciling BuildRun", namespace, request.Namespace, name, request.Name)
 
 	// Fetch the BuildRun instance
 	buildRun := &buildv1alpha1.BuildRun{}
@@ -144,6 +147,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 	if buildRun.GetLabels()[buildv1alpha1.LabelBuild] == "" {
 		buildRun.Labels[buildv1alpha1.LabelBuild] = build.Name
 		buildRun.Labels[buildv1alpha1.LabelBuildGeneration] = strconv.FormatInt(build.Generation, 10)
+		ctxlog.Info(ctx, "updating buildRun labels", namespace, request.Namespace, name, request.Name)
 		err = r.client.Update(ctx, buildRun)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -167,6 +171,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 				serviceAccount.Name = getGeneratedServiceAccountName(buildRun)
 				serviceAccount.Namespace = buildRun.Namespace
 
+				ctxlog.Info(ctx, "deleting service account", namespace, request.Namespace, name, request.Name)
 				if err = r.client.Delete(ctx, serviceAccount); err != nil && !apierrors.IsNotFound(err) {
 					ctxlog.Error(ctx, err, "Error during deletion of generated service account.")
 					return reconcile.Result{}, err
@@ -186,6 +191,8 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 		if buildRun.Status.BuildSpec == nil {
 			buildRun.Status.BuildSpec = &build.Spec
 		}
+
+		ctxlog.Info(ctx, "updating buildRun status", namespace, request.Namespace, name, request.Name)
 		err = r.client.Status().Update(ctx, buildRun)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -246,14 +253,15 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 	}
 
 	// create TaskRun if no TaskRun for that BuildRun exists
-	err = r.client.Create(context.TODO(), generatedTaskRun)
+	ctxlog.Info(ctx, "creating TaskRun from BuildRun", namespace, request.Namespace, name, generatedTaskRun.Name, "BuildRun", buildRun.Name)
+	err = r.client.Create(ctx, generatedTaskRun)
 	if err != nil {
 		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 		return reconcile.Result{}, handleError("Failed to create TaskRun if no TaskRun for that BuildRun exists", err, updateErr)
 	}
 
-	ctxlog.Info(ctx, "Generate and create TaskRun from Build and BuildRun", "TaskRun", generatedTaskRun.Name, "Build", build.Name, "BuildRun", buildRun.Name)
-	ctxlog.Info(ctx, "Reconciled Build", "Build.Namespace", buildRun.Namespace, "Build.Name", buildRun.Name)
+	ctxlog.Debug(ctx, "finishing reconciling BuildRun", namespace, request.Namespace, name, request.Name)
+
 	return reconcile.Result{}, nil
 }
 
@@ -276,70 +284,72 @@ func (r *ReconcileBuildRun) retrieveServiceAccount(ctx context.Context, build *b
 
 		// Create the service account, use CreateOrUpdate as it might exist already from a previous reconcilation that
 		// succeeded to create the service account but failed to update the build run that references it
-		op, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, serviceAccount, func() error {
+		ctxlog.Info(ctx, "create or update serviceAccount for BuildRun", namespace, buildRun.Namespace, name, serviceAccountName, "BuildRun", buildRun.Name)
+		op, err := controllerutil.CreateOrUpdate(ctx, r.client, serviceAccount, func() error {
 			serviceAccount.SetLabels(map[string]string{buildv1alpha1.LabelBuildRun: buildRun.Name})
 
 			ownerReference := metav1.NewControllerRef(buildRun, buildv1alpha1.SchemeGroupVersion.WithKind("BuildRun"))
 			serviceAccount.SetOwnerReferences([]metav1.OwnerReference{*ownerReference})
 
-			ApplyCredentials(build, serviceAccount)
+			ApplyCredentials(ctx, build, serviceAccount)
 
 			return nil
 		})
 		if err != nil {
 			return nil, err
 		}
-		ctxlog.Info(ctx, "Automatic generation of service account", "ServiceAccount", serviceAccount.Name, "Operation", op)
+		ctxlog.Debug(ctx, "Automatic generation of service account", namespace, serviceAccount.Namespace, name, serviceAccount.Name, "Operation", op)
 	} else {
 		// If ServiceAccount or the name of ServiceAccount in buildRun is nil, use pipeline serviceaccount
 		if buildRun.Spec.ServiceAccount == nil || buildRun.Spec.ServiceAccount.Name == nil {
 			serviceAccountName := pipelineServiceAccountName
-			err := r.client.Get(context.TODO(), types.NamespacedName{Name: serviceAccountName, Namespace: buildRun.Namespace}, serviceAccount)
+			err := r.client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: buildRun.Namespace}, serviceAccount)
 			if err != nil && !apierrors.IsNotFound(err) {
 				return nil, err
 			} else if apierrors.IsNotFound(err) {
 				serviceAccountName = defaultServiceAccountName
-				err = r.client.Get(context.TODO(), types.NamespacedName{Name: serviceAccountName, Namespace: buildRun.Namespace}, serviceAccount)
+				ctxlog.Info(ctx, "falling back to default serviceAccount", namespace, buildRun.Namespace)
+				err = r.client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: buildRun.Namespace}, serviceAccount)
 				if err != nil {
 					return nil, err
 				}
 			}
 		} else {
 			serviceAccountName := *buildRun.Spec.ServiceAccount.Name
-			err := r.client.Get(context.TODO(), types.NamespacedName{Name: serviceAccountName, Namespace: buildRun.Namespace}, serviceAccount)
+			err := r.client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: buildRun.Namespace}, serviceAccount)
 			if err != nil {
 				return nil, err
 			}
 		}
 
 		// Add credentials and update the service account
-		if modified := ApplyCredentials(build, serviceAccount); modified {
-			if err := r.client.Update(context.TODO(), serviceAccount); err != nil {
+		if modified := ApplyCredentials(ctx, build, serviceAccount); modified {
+			ctxlog.Info(ctx, "update ServiceAccount with secrets from build", namespace, serviceAccount.Namespace, name, serviceAccount.Name)
+			if err := r.client.Update(ctx, serviceAccount); err != nil {
 				return nil, err
 			}
 		}
-		ctxlog.Info(ctx, "Retrieve ServiceAccount from BuildRun", "ServiceAccount", serviceAccount.Name)
 	}
 	return serviceAccount, nil
 }
 
-func (r *ReconcileBuildRun) retrieveBuildStrategy(ctx context.Context, instance *buildv1alpha1.Build, request reconcile.Request) (*buildv1alpha1.BuildStrategy, error) {
+func (r *ReconcileBuildRun) retrieveBuildStrategy(ctx context.Context, build *buildv1alpha1.Build, request reconcile.Request) (*buildv1alpha1.BuildStrategy, error) {
 	buildStrategyInstance := &buildv1alpha1.BuildStrategy{}
 
-	err := r.client.Get(ctx, types.NamespacedName{Name: instance.Spec.StrategyRef.Name, Namespace: instance.Namespace}, buildStrategyInstance)
+	ctxlog.Debug(ctx, "retrieving BuildStrategy", namespace, build.Namespace, name, build.Name)
+	err := r.client.Get(ctx, types.NamespacedName{Name: build.Spec.StrategyRef.Name, Namespace: build.Namespace}, buildStrategyInstance)
 	if err != nil {
-		ctxlog.Error(ctx, err, "Failed to get BuildStrategy")
 		return nil, err
 	}
 	return buildStrategyInstance, nil
 }
 
-func (r *ReconcileBuildRun) retrieveClusterBuildStrategy(ctx context.Context, instance *buildv1alpha1.Build, request reconcile.Request) (*buildv1alpha1.ClusterBuildStrategy, error) {
+func (r *ReconcileBuildRun) retrieveClusterBuildStrategy(ctx context.Context, build *buildv1alpha1.Build, request reconcile.Request) (*buildv1alpha1.ClusterBuildStrategy, error) {
 	clusterBuildStrategyInstance := &buildv1alpha1.ClusterBuildStrategy{}
 
-	err := r.client.Get(ctx, types.NamespacedName{Name: instance.Spec.StrategyRef.Name}, clusterBuildStrategyInstance)
+	ctxlog.Debug(ctx, "retrieving ClusterBuildStrategy", namespace, build.Namespace, name, build.Name)
+	err := r.client.Get(ctx, types.NamespacedName{Name: build.Spec.StrategyRef.Name}, clusterBuildStrategyInstance)
 	if err != nil {
-		ctxlog.Error(ctx, err, "Failed to get ClusterBuildStrategy")
 		return nil, err
 	}
 	return clusterBuildStrategyInstance, nil
@@ -357,9 +367,9 @@ func (r *ReconcileBuildRun) retrieveTaskRun(ctx context.Context, build *buildv1a
 		Namespace:     buildRun.Namespace,
 		LabelSelector: labels.SelectorFromSet(lbls),
 	}
-	err := r.client.List(ctx, taskRunList, &opts)
 
-	if err != nil {
+	ctxlog.Info(ctx, "listing taskruns", namespace, buildRun.Namespace, name, buildRun.Name)
+	if err := r.client.List(ctx, taskRunList, &opts); err != nil {
 		return nil, err
 	}
 
@@ -374,6 +384,7 @@ func (r *ReconcileBuildRun) updateBuildRunErrorStatus(ctx context.Context, build
 	buildRun.Status.Reason = errorMessage
 	now := metav1.Now()
 	buildRun.Status.StartTime = &now
+	ctxlog.Debug(ctx, "updating buildRun status", namespace, buildRun.Namespace, name, buildRun.Name)
 	updateErr := r.client.Status().Update(ctx, buildRun)
 	return updateErr
 }

--- a/pkg/controller/buildrun/credentials.go
+++ b/pkg/controller/buildrun/credentials.go
@@ -1,39 +1,42 @@
 package buildrun
 
 import (
+	"context"
+
 	buildv1alpha1 "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
+	"github.com/redhat-developer/build/pkg/ctxlog"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
 // ApplyCredentials adds all credentials that are referenced by the build and adds them to the service account.
 // The function returns true if the service account was modified.
-func ApplyCredentials(build *buildv1alpha1.Build, serviceAccount *corev1.ServiceAccount) bool {
+func ApplyCredentials(ctx context.Context, build *buildv1alpha1.Build, serviceAccount *corev1.ServiceAccount) bool {
 
 	modified := false
 
 	// credentials of the source/git repo
 	sourceSecret := build.Spec.Source.SecretRef
 	if sourceSecret != nil {
-		modified = updateServiceAccountIfSecretNotLinked(sourceSecret, serviceAccount) || modified
+		modified = updateServiceAccountIfSecretNotLinked(ctx, sourceSecret, serviceAccount) || modified
 	}
 
 	// credentials of the 'Builder' image registry
 	builderImage := build.Spec.BuilderImage
 	if builderImage != nil && builderImage.SecretRef != nil {
-		modified = updateServiceAccountIfSecretNotLinked(builderImage.SecretRef, serviceAccount) || modified
+		modified = updateServiceAccountIfSecretNotLinked(ctx, builderImage.SecretRef, serviceAccount) || modified
 	}
 
 	// credentials of the 'output' image registry
 	sourceSecret = build.Spec.Output.SecretRef
 	if sourceSecret != nil {
-		modified = updateServiceAccountIfSecretNotLinked(sourceSecret, serviceAccount) || modified
+		modified = updateServiceAccountIfSecretNotLinked(ctx, sourceSecret, serviceAccount) || modified
 	}
 
 	return modified
 }
 
-func updateServiceAccountIfSecretNotLinked(sourceSecret *corev1.LocalObjectReference, serviceAccount *corev1.ServiceAccount) bool {
+func updateServiceAccountIfSecretNotLinked(ctx context.Context, sourceSecret *corev1.LocalObjectReference, serviceAccount *corev1.ServiceAccount) bool {
 	isSecretPresent := false
 	for _, credentialSecret := range serviceAccount.Secrets {
 		if credentialSecret.Name == sourceSecret.Name {
@@ -43,6 +46,7 @@ func updateServiceAccountIfSecretNotLinked(sourceSecret *corev1.LocalObjectRefer
 	}
 
 	if !isSecretPresent {
+		ctxlog.Debug(ctx, "adding secret to serviceAccount", "secret", sourceSecret.Name, "serviceAccount", serviceAccount.Name)
 		serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{
 			Name: sourceSecret.Name,
 		})

--- a/pkg/controller/buildrun/credentials_test.go
+++ b/pkg/controller/buildrun/credentials_test.go
@@ -1,6 +1,8 @@
 package buildrun_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	buildv1alpha1 "github.com/redhat-developer/build/pkg/apis/build/v1alpha1"
@@ -60,7 +62,7 @@ var _ = Describe("Credentials", func() {
 
 		It("adds the credentials to the service account", func() {
 			afterServiceAccount := beforeServiceAccount.DeepCopy()
-			modified := buildRunController.ApplyCredentials(build, afterServiceAccount)
+			modified := buildRunController.ApplyCredentials(context.TODO(), build, afterServiceAccount)
 
 			Expect(modified).To(BeTrue())
 			Expect(afterServiceAccount).To(Equal(expectedAfterServiceAccount))
@@ -86,7 +88,7 @@ var _ = Describe("Credentials", func() {
 
 		It("keeps the service account unchanged", func() {
 			afterServiceAccount := beforeServiceAccount.DeepCopy()
-			modified := buildRunController.ApplyCredentials(build, afterServiceAccount)
+			modified := buildRunController.ApplyCredentials(context.TODO(), build, afterServiceAccount)
 
 			Expect(modified).To(BeFalse())
 			Expect(afterServiceAccount).To(Equal(expectedAfterServiceAccount))
@@ -110,7 +112,7 @@ var _ = Describe("Credentials", func() {
 
 		It("keeps the service account unchanged", func() {
 			afterServiceAccount := beforeServiceAccount.DeepCopy()
-			modified := buildRunController.ApplyCredentials(build, afterServiceAccount)
+			modified := buildRunController.ApplyCredentials(context.TODO(), build, afterServiceAccount)
 
 			Expect(modified).To(BeFalse())
 			Expect(afterServiceAccount).To(Equal(expectedAfterServiceAccount))

--- a/pkg/controller/buildstrategy/buildstrategy_controller.go
+++ b/pkg/controller/buildstrategy/buildstrategy_controller.go
@@ -70,6 +70,6 @@ func (r *ReconcileBuildStrategy) Reconcile(request reconcile.Request) (reconcile
 	ctx, cancel := context.WithTimeout(r.ctx, r.config.CtxTimeOut)
 	defer cancel()
 
-	ctxlog.Info(ctx, "Reconciling BuildStrategy", "Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	ctxlog.Info(ctx, "reconciling BuildStrategy", "namespace", request.Namespace, "name", request.Name)
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go
+++ b/pkg/controller/clusterbuildstrategy/clusterbuildstrategy_controller.go
@@ -70,6 +70,6 @@ func (r *ReconcileClusterBuildStrategy) Reconcile(request reconcile.Request) (re
 	ctx, cancel := context.WithTimeout(r.ctx, r.config.CtxTimeOut)
 	defer cancel()
 
-	ctxlog.Info(ctx, "Reconciling ClusterBuildStrategy", "Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	ctxlog.Info(ctx, "reconciling ClusterBuildStrategy", "name", request.Name)
 	return reconcile.Result{}, nil
 }

--- a/pkg/ctxlog/context.go
+++ b/pkg/ctxlog/context.go
@@ -10,14 +10,13 @@ import (
 type contextLogger struct{}
 
 var (
-	nopLogger logr.Logger = logf.NullLogger{}
-	loggerKey             = &contextLogger{}
+	loggerKey = &contextLogger{}
 )
 
 // NewParentContext returns a new context from the
 // parent context.Background one. This new context
 // stores our logger implementation
-func NewParentContext(log *logr.Logger) context.Context {
+func NewParentContext(log logr.Logger) context.Context {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, loggerKey, log)
 	return ctx
@@ -29,8 +28,7 @@ func NewParentContext(log *logr.Logger) context.Context {
 func NewContext(ctx context.Context, name string) context.Context {
 	l := ExtractLogger(ctx)
 
-	lWithName := (*l).WithName(name)
-	l = &lWithName
+	l = l.WithName(name)
 
 	return context.WithValue(ctx, loggerKey, l)
 }
@@ -38,10 +36,10 @@ func NewContext(ctx context.Context, name string) context.Context {
 // ExtractLogger returns a logger based on the loggerKey
 // This function retrieves from an existing context the value,
 // which in this case is an instance of our logger
-func ExtractLogger(ctx context.Context) *logr.Logger {
-	log, ok := ctx.Value(loggerKey).(*logr.Logger)
+func ExtractLogger(ctx context.Context) logr.Logger {
+	log, ok := ctx.Value(loggerKey).(logr.Logger)
 	if !ok || log == nil {
-		return &nopLogger
+		return logf.NullLogger{}
 	}
 	return log
 }

--- a/pkg/ctxlog/log.go
+++ b/pkg/ctxlog/log.go
@@ -11,30 +11,30 @@ import (
 // NewLogger returns a new Logger instance
 // by using the operator-sdk log/zap logging
 // implementation
-func NewLogger(name string) *logr.Logger {
+func NewLogger(name string) logr.Logger {
 	l := zap.Logger()
 
 	logf.SetLogger(l)
 
 	l = l.WithName(name)
 
-	return &l
+	return l
 }
 
 // Error returns an ERROR level log from an specified context
 func Error(ctx context.Context, err error, msg string, v ...interface{}) {
 	l := ExtractLogger(ctx)
-	(*l).Error(err, msg, v...)
+	l.Error(err, msg, v...)
 }
 
 // Debug returns an DEBUG level log from an specified context
 func Debug(ctx context.Context, msg string, v ...interface{}) {
 	l := ExtractLogger(ctx)
-	(*l).V(1).Info(msg, v...)
+	l.V(1).Info(msg, v...)
 }
 
 // Info returns an INFO level log from an specified context
 func Info(ctx context.Context, msg string, v ...interface{}) {
 	l := ExtractLogger(ctx)
-	(*l).Info(msg, v...)
+	l.Info(msg, v...)
 }


### PR DESCRIPTION
For #247 

Most of the log statements should contain a message, a namespace, an object name at least.
- For INFO level, we try to keep it on a minimum.
- For DEBUG level, we try to add those on specific places, e.g. beginning/end of a function(e.g. Reconcile one). Or places we know we would be helpful later for debugging.

_Note_: When we return an error, we are not logging that, the reason goes back to what is stated in https://dave.cheney.net/2015/11/05/lets-talk-about-logging, we basically just return the error to the parent call . The controller-runtime will send the error to STDOUT together with a stacktrace. This should be enough.

We also fix a bad practice implemented in the ctxlog logger package. We remove a pointer we use to have for the logger interface, it was basically not needed(_interface do not require pointers_)

Signed-off-by: Sascha Schwarze <schwarzs@de.ibm.com>