### PR TITLE
Fix readiness/liveness probe when HA is enable

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"github.com/operator-framework/operator-sdk/pkg/ready"
 
 	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
@@ -88,6 +89,14 @@ func main() {
 		ctxlog.Error(ctx, err, "")
 		os.Exit(1)
 	}
+
+	r := ready.NewFileReady()
+	err = r.Set()
+	if err != nil {
+		ctxlog.Error(ctx, err, "Checking for /tmp/operator-sdk-ready failed")
+		os.Exit(1)
+	}
+	defer r.Unset()
 
 	// Become the leader before proceeding
 	err = leader.Become(ctx, "build-operator-lock")

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -32,14 +32,16 @@ spec:
             - name: OPERATOR_NAME
               value: "build-operator"
           livenessProbe:
-            httpGet:
-              path: /metrics
-              port: 8383
+            exec:
+              command:
+                - stat
+                - /tmp/operator-sdk-ready
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
-            httpGet:
-              path: /metrics
-              port: 8383
+            exec:
+              command:
+                - stat
+                - /tmp/operator-sdk-ready
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
When running in HA mode, the previous localhost:8383/metrics
endpoint was not available for pods that are not leaders. This
end-up in pods having a CrashLoopBackOff  STATUS.

In order to fix this, we are introducing a different approach on
how we check the Readiness/Liveness by using the operator-sdk ready
package.

Also, we test this manually, it should be working when HA is enabled.

Signed-off-by: EEE <encalada@de.ibm.com>