### PR TITLE
This is aiming to help to mitigate performance issues in travis

### DIFF
--- a/samples/build/build_buildpacks-v3-heroku_cr.yaml
+++ b/samples/build/build_buildpacks-v3-heroku_cr.yaml
@@ -9,5 +9,12 @@ spec:
   strategy:
     name: buildpacks-v3-heroku
     kind: ClusterBuildStrategy
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+    request:
+      cpu: "250m"
+      memory: "65Mi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -14,7 +14,7 @@ spec:
       cpu: "500m"
       memory: "1Gi"
     request:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "250m"
+      memory: "65Mi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/samples/build/build_buildpacks-v3_cr.yaml
+++ b/samples/build/build_buildpacks-v3_cr.yaml
@@ -11,5 +11,12 @@ spec:
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+    request:
+      cpu: "250m"
+      memory: "65Mi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/samples/build/build_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/build/build_buildpacks-v3_namespaced_cr.yaml
@@ -14,7 +14,7 @@ spec:
       cpu: "500m"
       memory: "1Gi"
     request:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "250m"
+      memory: "65Mi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/data/build_buildpacks-v3-heroku_cr_private_github.yaml
+++ b/test/data/build_buildpacks-v3-heroku_cr_private_github.yaml
@@ -9,5 +9,12 @@ spec:
   strategy:
     name: buildpacks-v3-heroku
     kind: ClusterBuildStrategy
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+    request:
+      cpu: "250m"
+      memory: "65Mi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/data/build_buildpacks-v3_cr_private_github.yaml
+++ b/test/data/build_buildpacks-v3_cr_private_github.yaml
@@ -9,5 +9,12 @@ spec:
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+    request:
+      cpu: "250m"
+      memory: "65Mi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/data/build_buildpacks-v3_golang_cr.yaml
+++ b/test/data/build_buildpacks-v3_golang_cr.yaml
@@ -10,5 +10,12 @@ spec:
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+    request:
+      cpu: "250m"
+      memory: "65Mi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/data/build_buildpacks-v3_java_cr.yaml
+++ b/test/data/build_buildpacks-v3_java_cr.yaml
@@ -10,5 +10,12 @@ spec:
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+    request:
+      cpu: "250m"
+      memory: "65Mi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/data/build_buildpacks-v3_php_cr.yaml
+++ b/test/data/build_buildpacks-v3_php_cr.yaml
@@ -10,5 +10,12 @@ spec:
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+    request:
+      cpu: "250m"
+      memory: "65Mi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/data/build_buildpacks-v3_ruby_cr.yaml
+++ b/test/data/build_buildpacks-v3_ruby_cr.yaml
@@ -10,5 +10,12 @@ spec:
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+    request:
+      cpu: "250m"
+      memory: "65Mi"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app


### PR DESCRIPTION
I think mainly for buildpacks, where we have many containers, we might have not pay attention on the container resources implications.

Here are some facts:
- By not defining container limits/requests, containers are able to
  use as much as they need for cpu and memory, leading to
  OOM kill or CPU throttle
- Travis have by default what I think is, 4G RAM and 4.5MB memory, with
  2 cores.
- Limits are fine to be 500m CPU, 1Gi memory. I dont think we can hit any
  of the issues above with this limits. Maybe only slower tests.

Also, pls keep in mind that when setting limits without requests, k8s will
default the request to the limits.

I enjoy reading the following:
- https://sysdig.com/blog/kubernetes-limits-requests/
- https://medium.com/@betz.mark/understanding-resource-limits-in-kubernetes-cpu-time-9eff74d3161b
- https://medium.com/@betz.mark/understanding-resource-limits-in-kubernetes-memory-6b41e9a955f9