### PR TITLE
Working Directory Attribute

### DIFF
--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -7,7 +7,7 @@ spec:
   buildSteps:
     - name: step-build-and-push
       image: gcr.io/kaniko-project/executor:v0.23.0
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       securityContext:
         runAsUser: 0
         capabilities:

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -42,4 +42,4 @@ spec:
       volumeMounts:
         - mountPath: /gen-source
           name: gen-source
-      workingdir: /gen-source
+      workingDir: /gen-source


### PR DESCRIPTION
Fixing the camel-case capitalization on a couple places. In [core-v1/Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core) it species `workingDir` instead of `workingdir`.