### PR TITLE
Fix the nil pointer error when builder controller is restarted

### DIFF
--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -190,6 +190,9 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 			buildRun.Status.BuildSpec = &build.Spec
 		}
 
+		buildRun.Status.LatestTaskRunRef = &lastTaskRun.Name
+		buildRun.Status.StartTime = lastTaskRun.Status.StartTime
+
 		if lastTaskRun.Status.CompletionTime != nil && buildRun.Status.CompletionTime == nil {
 			buildRun.Status.CompletionTime = lastTaskRun.Status.CompletionTime
 
@@ -201,9 +204,6 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 			buildmetrics.BuildRunEstablishObserve(build.Spec.StrategyRef.Name, buildRun.Namespace, buildRunEstablishDuring)
 			buildmetrics.BuildRunCompletionObserve(build.Spec.StrategyRef.Name, buildRun.Namespace, buildRunCompletionDuring)
 		}
-
-		buildRun.Status.LatestTaskRunRef = &lastTaskRun.Name
-		buildRun.Status.StartTime = lastTaskRun.Status.StartTime
 
 		ctxlog.Info(ctx, "updating buildRun status", namespace, request.Namespace, name, request.Name)
 		err = r.client.Status().Update(ctx, buildRun)


### PR DESCRIPTION
This is a bug which introduced by the new custom metric feature.

In some special cases, the build controller cannot get `buildRun.Status.StartTime.Time` then report **nil pointer** error:

**How to reproduce:**
- Start build controller
- Run some buildrun tests parallel
- Stop the build controller pod to stop service
- Some of the buildruns already create taskrun, but don't update the `buildRun.Status.StartTime.Time` correctly and the taskrun is running
- After several minutes, the taskrun is completed
- Start the build controller
- There is no StartTime in the buildrun status:
```
kubectl get br perf-br-project3712-1 -n 83ef14eb-10ad -oyaml
apiVersion: build.dev/v1alpha1
kind: BuildRun
metadata:
  generation: 2
  labels:
    build.build.dev/generation: "1"
    build.build.dev/name: perf-b-project3712-1
  name: perf-br-project3712-1
  namespace: 83ef14eb-10ad
  resourceVersion: "218311997"
  selfLink: /apis/build.dev/v1alpha1/namespaces/83ef14eb-10ad/buildruns/perf-br-project3712-1
  uid: ec2315a4-e311-41a5-ab9e-bc18fc9dcf7c
spec:
  buildRef:
    name: perf-b-project3712-1
  serviceAccount: {}
```

But our logic try to calculate the `buildRunEstablishDuring` by using:
```
buildRunEstablishDuring := buildRun.Status.StartTime.Time.Sub(buildRun.CreationTimestamp.Time)
```

Then report error:
```
...
{"level":"info","ts":1594175306.1236908,"logger":"build.buildrun-controller","msg":"deleting service account","namespace":"ff776997-2410","name":"kaniko-golang-buildrun"}
{"level":"info","ts":1594175306.1382077,"logger":"build.buildrun-controller","msg":"updating buildRun status","namespace":"ff776997-2410","name":"kaniko-golang-buildrun"}
{"level":"info","ts":1594175306.1579459,"logger":"build.buildrun-controller","msg":"listing taskruns","namespace":"f99fb81b-f45f","name":"perf-br-project3703-1"}
E0708 02:28:26.158123       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 1783 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1599b00, 0x257bf70)
	/go/src/github.com/redhat-developer/build/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/redhat-developer/build/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x1599b00, 0x257bf70)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/redhat-developer/build/pkg/controller/buildrun.(*ReconcileBuildRun).Reconcile(0xc0008a9540, 0xc0007d3700, 0xd, 0xc000ae47a0, 0x15, 0xc000d97c00, 0x0, 0x0, 0x0)
	/go/src/github.com/redhat-developer/build/pkg/controller/buildrun/buildrun_controller.go:200 +0x86e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0001aeb40, 0x15f4120, 0xc000c186e0, 0x0)
	/go/src/github.com/redhat-developer/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256 +0x162
...
```

Fixed this error by moving the `buildRun.Status.StartTime = lastTaskRun.Status.StartTime` before `buildRunEstablishDuring := buildRun.Status.StartTime.Time.Sub(buildRun.CreationTimestamp.Time)`