### PR TITLE
Bring ruby e2e test back

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -204,9 +204,6 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	Context("when a Buildpacks v3 build is defined for a ruby runtime", func() {
 
 		BeforeEach(func() {
-			// issue track in paketo side: https://github.com/paketo-community/ruby/issues/59
-			Skip("Skipping test case because Ruby support in paketo is still under development.")
-
 			testID = generateTestID("buildpacks-v3-ruby")
 
 			// create the build definition


### PR DESCRIPTION
Community has supported ruby buildpack, now. Pls refer to [here](https://github.com/paketo-community/ruby/issues/59#issuecomment-654869593). So we need to bring ruby e2e test back.

Also I have verified locally, ruby apps can be build successfully.
```
root@xxx-0:~/gopath/src/github.com/cf-acceptance-tests/assets# pack build us.icr.io/zoe_nmaespace/ruby-test  --builder gcr.io/paketo-buildpacks/builder:latest --path=dora/
latest: Pulling from paketo-buildpacks/builder
11f6db2e1cf8: Already exists 
5fc72bd1c95d: Already exists 
4c1a0023eeb2: Already exists 
efb025c4d658: Pulling fs layer 
... ...
... ....
89732bc75041: Pull complete 
Digest: sha256:e8416da7d2e1a8141af0768ca01a300b497d475d2d4843b5964443babd4b5362
Status: Downloaded newer image for gcr.io/paketo-buildpacks/builder:latest
full-cnb-cf: Pulling from paketo-buildpacks/run
Digest: sha256:47b284b934fa4bc6b518bac93e019448d5abf232d76419fd193ff63196e77a89
Status: Downloaded newer image for gcr.io/paketo-buildpacks/run:full-cnb-cf
===> DETECTING
[detector] paketo-buildpacks/procfile 1.3.9
===> ANALYZING
[analyzer] Previous image with name "us.icr.io/zoe_nmaespace/ruby-test:latest" not found
===> RESTORING
===> BUILDING
[builder] 
[builder] Paketo Procfile Buildpack 1.3.9
[builder]   https://github.com/paketo-buildpacks/procfile
[builder]   Process types:
[builder]     web:    bundle exec rackup config.ru -p $PORT
[builder]     worker: bundle exec rackup config.ru
===> EXPORTING
[exporter] Adding layer 'launcher'
[exporter] Adding 1/1 app layer(s)
[exporter] Adding layer 'config'
[exporter] *** Images (efaf95d47f30):
[exporter]       us.icr.io/zoe_nmaespace/ruby-test:latest
Successfully built image us.icr.io/zoe_nmaespace/ruby-test
```