### PR TITLE
Refine build_buildrun_establish_duration_seconds buckets and make buckets configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ crds:
 	@hack/crd.sh install
 
 local: crds build
+	OPERATOR_NAME=build-operator \
 	operator-sdk run --local --operator-flags="$(ZAP_FLAGS)"
 
 clean:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,3 +10,27 @@ Following build metrics are exposed at service `build-operator-metrics` on port 
 | `build_buildruns_completed_total` | Counter | Number of total completed BuildRuns. | buildstrategy=<build_buildstrategy_name> | experimental |
 | `build_buildrun_establish_duration_seconds` | Histogram | BuildRun establish duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
 | `build_buildrun_completion_duration_seconds` | Histogram | BuildRun completion duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
+
+Environment variables can be set to use custom buckets for the histogram metrics:
+
+| Metric                                       | Environment variable             | Default                                  |
+| -------------------------------------------- | -------------------------------- | ---------------------------------------- |
+| `build_buildrun_establish_duration_seconds`  | `PROMETHEUS_BR_EST_DUR_BUCKETS`  | `0,1,2,3,5,7,10,15,20,30`                |
+| `build_buildrun_completion_duration_seconds` | `PROMETHEUS_BR_COMP_DUR_BUCKETS` | `50,100,150,200,250,300,350,400,450,500` |
+
+The values have to be a comma-separated list of numbers. You need to set the environment variable for the build operator for your customization to become active. When running locally, set the variable right before starting the operator:
+
+```bash
+export PROMETHEUS_BR_COMP_DUR_BUCKETS=30,60,90,120,180,240,300,360,420,480
+make local
+```
+
+When you are deploying the build operator in your Kubernetes cluster, you need to extend the `spec.containers[0].spec.env` section of the sample deployment file, [operator.yaml](../deploy/operator.yaml), to add an additional entry:
+
+```yaml
+[...]
+  env:
+  - name: PROMETHEUS_BR_COMP_DUR_BUCKETS
+    value: "30,60,90,120,180,240,300,360,420,480"
+[...]
+```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,19 +3,32 @@ package config
 import (
 	"os"
 	"strconv"
+	"strings"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
 	contextTimeout = 300 * time.Second
 	// A number in seconds to define a context Timeout
 	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5
-	contexTimeoutEnvVar = "CTX_TIMEOUT"
+	contextTimeoutEnvVar = "CTX_TIMEOUT"
 
 	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v0.24.0"
 	// kanikoImageEnvVar environment variable for Kaniko container image, for instance:
 	// KANIKO_CONTAINER_IMAGE="gcr.io/kaniko-project/executor:v0.24.0"
 	kanikoImageEnvVar = "KANIKO_CONTAINER_IMAGE"
+
+	// environment variable to override the buckets
+	metricBuildRunCompletionDurationBucketsEnvVar = "PROMETHEUS_BR_COMP_DUR_BUCKETS"
+	metricBuildRunEstablishDurationBucketsEnvVar  = "PROMETHEUS_BR_EST_DUR_BUCKETS"
+)
+
+var (
+	// arrays are not possible as constants
+	metricBuildRunCompletionDurationBuckets = prometheus.LinearBuckets(50, 50, 10)
+	metricBuildRunEstablishDurationBuckets  = []float64{0, 1, 2, 3, 5, 7, 10, 15, 20, 30}
 )
 
 // Config hosts different parameters that
@@ -23,6 +36,13 @@ const (
 type Config struct {
 	CtxTimeOut           time.Duration
 	KanikoContainerImage string
+	Prometheus           PrometheusConfig
+}
+
+// PrometheusConfig contains the specific configuration for the
+type PrometheusConfig struct {
+	BuildRunCompletionDurationBuckets []float64
+	BuildRunEstablishDurationBuckets  []float64
 }
 
 // NewDefaultConfig returns a new Config, with context timeout and default Kaniko image.
@@ -30,12 +50,16 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		CtxTimeOut:           contextTimeout,
 		KanikoContainerImage: kanikoDefaultImage,
+		Prometheus: PrometheusConfig{
+			BuildRunCompletionDurationBuckets: metricBuildRunCompletionDurationBuckets,
+			BuildRunEstablishDurationBuckets:  metricBuildRunEstablishDurationBuckets,
+		},
 	}
 }
 
 // SetConfigFromEnv updates the configuration managed by environment variables.
 func (c *Config) SetConfigFromEnv() error {
-	timeout := os.Getenv(contexTimeoutEnvVar)
+	timeout := os.Getenv(contextTimeoutEnvVar)
 	if timeout != "" {
 		i, err := strconv.Atoi(timeout)
 		if err != nil {
@@ -48,5 +72,38 @@ func (c *Config) SetConfigFromEnv() error {
 	if kanikoImage != "" {
 		c.KanikoContainerImage = kanikoImage
 	}
+
+	buildRunCompletionDurationBucketsEnvVarValue := os.Getenv(metricBuildRunCompletionDurationBucketsEnvVar)
+	if buildRunCompletionDurationBucketsEnvVarValue != "" {
+		buildRunCompletionDurationBuckets, err := stringToFloat64Array(strings.Split(buildRunCompletionDurationBucketsEnvVarValue, ","))
+		if err != nil {
+			return err
+		}
+		c.Prometheus.BuildRunCompletionDurationBuckets = buildRunCompletionDurationBuckets
+	}
+
+	buildRunEstablishDurationBucketsEnvVarValue := os.Getenv(metricBuildRunEstablishDurationBucketsEnvVar)
+	if buildRunEstablishDurationBucketsEnvVarValue != "" {
+		buildRunEstablishDurationBuckets, err := stringToFloat64Array(strings.Split(buildRunEstablishDurationBucketsEnvVarValue, ","))
+		if err != nil {
+			return err
+		}
+		c.Prometheus.BuildRunEstablishDurationBuckets = buildRunEstablishDurationBuckets
+	}
+
 	return nil
+}
+
+func stringToFloat64Array(strings []string) ([]float64, error) {
+	floats := make([]float64, len(strings))
+
+	for i, string := range strings {
+		float, err := strconv.ParseFloat(string, 64)
+		if err != nil {
+			return nil, err
+		}
+		floats[i] = float
+	}
+
+	return floats, nil
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,10 +1,13 @@
 package metrics
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"time"
+	"github.com/redhat-developer/build/pkg/config"
 )
 
 var _ = Describe("Custom Metrics", func() {
@@ -16,6 +19,8 @@ var _ = Describe("Custom Metrics", func() {
 	Context("when create a new kaniko buildrun", func() {
 		buildStrategy = "kaniko"
 		namespace = "default"
+
+		InitPrometheus(config.NewDefaultConfig())
 
 		BuildCountInc(buildStrategy)
 		BuildRunCountInc(buildStrategy)
@@ -47,6 +52,8 @@ var _ = Describe("Custom Metrics", func() {
 	Context("when create a new buildpacks buildrun", func() {
 		buildStrategy = "buildpacks"
 		namespace = "test"
+
+		InitPrometheus(config.NewDefaultConfig())
 
 		BuildCountInc(buildStrategy)
 		BuildRunCountInc(buildStrategy)


### PR DESCRIPTION
The `build_buildrun_establish_duration_seconds` histogram metric used the following buckets: 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5.

Two issues exist with that:

1. Values with .5 cannot exist because k8s timestamps have no milliseconds. Those are therefore not of value.
2. Longer durations cannot be differentiated which makes it impossible to define reasonable alerts.

The new buckets for the metric are: 0, 1, 2, 3, 5, 7, 10, 15, 20, 30. The number of buckets is unchanged, but the longer durations can be better monitored.

In addition, I am changing the metrics implementation to get the buckets from the configuration and I allow environment variables to overwrite the defaults.

The downside of that is that the metrics package cannot anymore instantiate the histograms statically but requires the config. This means that those metrics can only be initializes in `InitPrometheus`. This works fine at runtime but is a little issue for the unit tests because there is no single "main" for them. I therefore had to add the `initialized` flag (see https://github.com/redhat-developer/build/commit/d42fada56ede2f0f5d9f0ecfae2f97010ed97f2a#diff-7cbe8e056d62a2de30c7066e359bd9c9R35-R44) which I do not like so much. Better ideas are welcome.