### PR TITLE
Drop containers `protocol` from "required"

### DIFF
--- a/deploy/crds/build.dev_buildstrategies_crd.yaml
+++ b/deploy/crds/build.dev_buildstrategies_crd.yaml
@@ -580,6 +580,7 @@ spec:
                             description: Protocol for port. Must be UDP, TCP, or SCTP.
                               Defaults to "TCP".
                             type: string
+                            default: TCP
                         required:
                         - containerPort
                         type: object

--- a/deploy/crds/build.dev_clusterbuildstrategies_crd.yaml
+++ b/deploy/crds/build.dev_clusterbuildstrategies_crd.yaml
@@ -581,6 +581,7 @@ spec:
                             description: Protocol for port. Must be UDP, TCP, or SCTP.
                               Defaults to "TCP".
                             type: string
+                            default: TCP
                         required:
                         - containerPort
                         type: object


### PR DESCRIPTION
* Without this change, our CRDs won't work for kubernetes 1.18 , see https://github.com/redhat-developer/build/issues/284
* Till we find a better solution, we'll have to manually modify ( or have a `sed` script ) to make our CRDs work with kube 1.18 
Noticed that a lot of projects have done this.

Ref https://github.com/operator-framework/operator-sdk/issues/3235


#### Before
```
$ oc apply -f deploy/crds/build.dev_buildstrategies_crd.yaml 

The CustomResourceDefinition "buildstrategies.build.dev" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[buildSteps].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property
```


#### After

```
oc apply -f deploy/crds/build.dev_buildstrategies_crd.yaml 
customresourcedefinition.apiextensions.k8s.io/buildstrategies.build.dev created
````