### PR TITLE
Improve BuildRun Reconciler logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ vendor: go.mod go.sum
 .PHONY: build
 build: $(OPERATOR)
 
-$(OPERATOR): vendor
+$(OPERATOR):
 	go build $(GO_FLAGS) -o $(OPERATOR) cmd/manager/main.go
 
 install-ginkgo:
@@ -124,8 +124,7 @@ crds:
 	@hack/crd.sh install
 
 local: crds build
-	OPERATOR_NAME=build-operator \
-	operator-sdk run --local --operator-flags="$(ZAP_FLAGS)"
+	operator-sdk run --local --operator-flags="$(ZAP_FLAGS)" --watch-namespace="test-build"
 
 clean:
 	rm -rf $(OUTPUT_DIR)

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -375,7 +375,7 @@ func (r *ReconcileBuildRun) createTaskRun(ctx context.Context, build *buildv1alp
 			return nil, err
 		}
 		if buildStrategy != nil {
-			generatedTaskRun, err = GenerateTaskRun(build, buildRun, serviceAccount.Name, buildStrategy.Spec.BuildSteps)
+			generatedTaskRun, err = GenerateTaskRun(r.config, build, buildRun, serviceAccount.Name, buildStrategy.Spec.BuildSteps)
 			if err != nil {
 				updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 				return nil, handleError("Failed to generate the taskrun with buildStrategy", err, updateErr)
@@ -387,7 +387,7 @@ func (r *ReconcileBuildRun) createTaskRun(ctx context.Context, build *buildv1alp
 			return nil, err
 		}
 		if clusterBuildStrategy != nil {
-			generatedTaskRun, err = GenerateTaskRun(build, buildRun, serviceAccount.Name, clusterBuildStrategy.Spec.BuildSteps)
+			generatedTaskRun, err = GenerateTaskRun(r.config, build, buildRun, serviceAccount.Name, clusterBuildStrategy.Spec.BuildSteps)
 			if err != nil {
 				updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 				return nil, handleError("Failed to generate the taskrun with clusterBuildStrategy", err, updateErr)

--- a/pkg/controller/buildrun/generate_taskrun.go
+++ b/pkg/controller/buildrun/generate_taskrun.go
@@ -195,8 +195,8 @@ func GenerateTaskRun(
 
 	expectedTaskRun := &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: buildRun.Name + "-",
-			Namespace:    buildRun.Namespace,
+			Name:      buildRun.Name,
+			Namespace: buildRun.Namespace,
 			Labels: map[string]string{
 				buildv1alpha1.LabelBuild:              build.Name,
 				buildv1alpha1.LabelBuildGeneration:    strconv.FormatInt(build.Generation, 10),

--- a/pkg/controller/buildrun/generate_taskrun_test.go
+++ b/pkg/controller/buildrun/generate_taskrun_test.go
@@ -143,7 +143,7 @@ var _ = Describe("GenerateTaskrun", func() {
 			})
 
 			It("should ensure generated TaskRun's basic information are correct", func() {
-				Expect(strings.Contains(got.GenerateName, buildRun.Name+"-")).To(Equal(true))
+				Expect(strings.Contains(got.Name, buildRun.Name)).To(Equal(true))
 				Expect(got.Namespace).To(Equal(namespace))
 				Expect(got.Spec.ServiceAccountName).To(Equal(buildpacks + "-serviceaccount"))
 				Expect(got.Labels[buildv1alpha1.LabelBuild]).To(Equal(build.Name))
@@ -214,7 +214,7 @@ var _ = Describe("GenerateTaskrun", func() {
 			})
 
 			It("should ensure generated TaskRun's basic information are correct", func() {
-				Expect(strings.Contains(got.GenerateName, buildRun.Name+"-")).To(Equal(true))
+				Expect(strings.Contains(got.Name, buildRun.Name)).To(Equal(true))
 				Expect(got.Namespace).To(Equal(namespace))
 				Expect(got.Spec.ServiceAccountName).To(Equal(buildpacks + "-serviceaccount"))
 				Expect(got.Labels[buildv1alpha1.LabelBuild]).To(Equal(build.Name))

--- a/pkg/controller/buildrun/runtime_image_test.go
+++ b/pkg/controller/buildrun/runtime_image_test.go
@@ -74,7 +74,7 @@ var _ = Describe("runtime-image", func() {
 	Context("rendering entrypoint", func() {
 		It("expect entrypoint concatenated", func() {
 			entrypoint := renderEntrypoint(b.Spec.Runtime.Entrypoint)
-			fmt.Printf("Entrypoint: ---\n%s\n---\n", entrypoint)
+			// fmt.Printf("Entrypoint: ---\n%s\n---\n", entrypoint)
 
 			Expect(entrypoint).To(Equal("\"/bin/bash\", \"-x\", \"-c\""))
 		})
@@ -84,7 +84,7 @@ var _ = Describe("runtime-image", func() {
 
 		It("expect a complete dockerfile", func() {
 			dockerfile, err := renderRuntimeDockerfile(b)
-			fmt.Printf("Dockerfile.runtime: ---\n%s\n---\n", dockerfile)
+			// fmt.Printf("Dockerfile.runtime: ---\n%s\n---\n", dockerfile)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dockerfile).ToNot(BeNil())

--- a/samples/build/build_kaniko_cr.yaml
+++ b/samples/build/build_kaniko_cr.yaml
@@ -3,8 +3,8 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 metadata:
   name: kaniko-golang-build
-  annotations:
-    build.build.dev/build-run-deletion: "true"
+  # annotations:
+  #   build.build.dev/build-run-deletion: "true"
 spec:
   source:
     url: https://github.com/sbose78/taxi
@@ -13,4 +13,6 @@ spec:
     kind: ClusterBuildStrategy
   dockerfile: Dockerfile
   output:
-    image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app
+    image: us.icr.io/source-to-image-build/docker-simple
+    credentials:
+      name: icr-knbuild


### PR DESCRIPTION
This should provide improvements on the controller performance.

The main problem is that we are reconciling for every change on a
TaskRun StartedTime even if the REASON is not changed. This is leading
too a large amount of reconciliations in the BuildRun(> 10) for a single
Build, plus all the API calls we do per Reconcile.

This PR improves this by using a more fine grained set of Predicates when
watching TaskRuns and also it make use of the EnqueueRequestsFromMapFunc that
generates the List of Reconciles we need to do per event, instead of Reconciling
for every event.