### PR TITLE
Minor fixes around our k8s resources

### DIFF
--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: build-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: build-operator
+  namespace: build-operator
 spec:
   replicas: 1
   selector:

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: build-operator
+  namespace: build-operator

--- a/docs/development/deploying.md
+++ b/docs/development/deploying.md
@@ -14,13 +14,7 @@ The following set of steps highlight how to deploy a Build operator pod into an 
 
 2. Reference the generated image name in the [operator.yaml](../../deploy/operator.yaml). The `spec.template.containers[0].image` value should be modified.
 
-3. Target your Kubernetes cluster and create the `build-operator` namespace.
-
-    ```sh
-    kubectl create ns build-operator
-    ```
-
-4. Install Tekton pipeline controller:
+3. Target your Kubernetes cluster and install the Tekton pipeline:
 
     ```sh
     pushd $GOPATH/src/github.com/redhat-developer/build
@@ -28,7 +22,7 @@ The following set of steps highlight how to deploy a Build operator pod into an 
     popd
     ```
 
-5. Install the Build operator pod.
+4. Install the Build operator pod and all related resources.
 
     ```sh
     pushd $GOPATH/src/github.com/redhat-developer/build
@@ -36,5 +30,4 @@ The following set of steps highlight how to deploy a Build operator pod into an 
     popd
     ```
 
-The above five steps give you a running Build operator that executes the code from your current branch.
-
+The above four steps give you a running Build operator that executes the code from your current branch.

--- a/docs/development/deploying.md
+++ b/docs/development/deploying.md
@@ -1,0 +1,40 @@
+# Deploying the operator pod
+
+The following set of steps highlight how to deploy a Build operator pod into an existing Kubernetes cluster.
+
+1. Build a custom docker image from this repository. This can be done with Docker, for example:
+
+   ```sh
+   pushd $GOPATH/src/github.com/redhat-developer/build
+   docker build -t eeeoo/build-operator:master .
+   docker push eeeoo/build-operator:master
+   popd
+   ```
+   Just to illustrate the above, you can find the image in [dockerhub](https://hub.docker.com/repository/docker/eeeoo/build-operator)
+
+2. Reference the generated image name in the [operator.yaml](../../deploy/operator.yaml). The `spec.template.containers[0].image` value should be modified.
+
+3. Target your Kubernetes cluster and create the `build-operator` namespace.
+
+    ```sh
+    kubectl create ns build-operator
+    ```
+
+4. Install Tekton pipeline controller:
+
+    ```sh
+    pushd $GOPATH/src/github.com/redhat-developer/build
+    ./hack/install-tekton.sh
+    popd
+    ```
+
+5. Install the Build operator pod.
+
+    ```sh
+    pushd $GOPATH/src/github.com/redhat-developer/build
+    ./hack/crd.sh install
+    popd
+    ```
+
+The above five steps give you a running Build operator that executes the code from your current branch.
+

--- a/hack/crd.sh
+++ b/hack/crd.sh
@@ -9,6 +9,7 @@
 ACTION="${1}"
 CRDS=(
     # operator components
+    deploy/namespace.yaml
     deploy/role.yaml
     deploy/role_binding.yaml
     deploy/service_account.yaml


### PR DESCRIPTION
Fix Build operator resources:
- The SA YAML was missing the namespace, same case for the Deployment YAML

Add docs around how to deploy a pod running the Build:
- I already struggle to explain this to two different people, I think
is always useful to allow users to get a pod running this operator,
therefore adding docs around it.

