### PR TITLE
Stop working on the buildrun if build.registered=false

### DIFF
--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -195,6 +195,11 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 		return reconcile.Result{}, handleError("Failed to fetch the Build instance", err, updateErr)
 	}
+	if build.Status.Registered != corev1.ConditionTrue {
+		err := fmt.Errorf("The Build is not registered correctly, registered status: %s, reason: %s", build.Status.Registered, build.Status.Reason)
+		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
+		return reconcile.Result{}, handleError("Build is not ready", err, updateErr)
+	}
 
 	if buildRun.GetLabels() == nil {
 		buildRun.Labels = make(map[string]string)

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -421,6 +421,28 @@ func (c *Catalog) DefaultBuild(buildName string, strategyName string, strategyKi
 				Kind: &strategyKind,
 			},
 		},
+		Status: build.BuildStatus{
+			Registered: corev1.ConditionTrue,
+		},
+	}
+}
+
+// DefaultBuildWithFalseRegistered returns a minimal Build object with a FALSE Registered
+func (c *Catalog) DefaultBuildWithFalseRegistered(buildName string, strategyName string, strategyKind build.BuildStrategyKind) *build.Build {
+	return &build.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: buildName,
+		},
+		Spec: build.BuildSpec{
+			StrategyRef: &build.StrategyRef{
+				Name: strategyName,
+				Kind: &strategyKind,
+			},
+		},
+		Status: build.BuildStatus{
+			Registered: corev1.ConditionFalse,
+			Reason: "something bad happened",
+		},
 	}
 }
 


### PR DESCRIPTION
Fixes #301 

- The buildrun controller is able to check the build's registered status.
If `build.Status.Registered` is false, it should stop working on further service account and taskrun.
- To avoid `Unexpected Error` of other unittest cases, the mocked `DefultBuild` has the `build.Registered` set to be True.
- Also, for testing the case that `build.Registered` is false, the mocked `DefaultBuildWithFalseRegistered` is created in catalog.go