### PR TITLE
Handle garbage Tekton TaskRun in build run controller

### DIFF
--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -8,6 +8,7 @@ import (
 var (
 	LabelBuildRun           = "buildrun.build.dev/name"
 	LabelBuildRunGeneration = "buildrun.build.dev/generation"
+	LabelBuildRunUid        = "buildrun.build.dev/uid"
 )
 
 // BuildRunSpec defines the desired state of BuildRun

--- a/pkg/controller/buildrun/generate_taskrun.go
+++ b/pkg/controller/buildrun/generate_taskrun.go
@@ -202,6 +202,7 @@ func GenerateTaskRun(
 				buildv1alpha1.LabelBuildGeneration:    strconv.FormatInt(build.Generation, 10),
 				buildv1alpha1.LabelBuildRun:           buildRun.Name,
 				buildv1alpha1.LabelBuildRunGeneration: strconv.FormatInt(buildRun.Generation, 10),
+				buildv1alpha1.LabelBuildRunUid:        string(buildRun.UID),
 			},
 		},
 		Spec: v1beta1.TaskRunSpec{

--- a/test/data/build_kaniko_cr_fast.yaml
+++ b/test/data/build_kaniko_cr_fast.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: Build
+metadata:
+  name: kaniko-fast
+spec:
+  source:
+    url: https://github.com/SaschaSchwarze0/docker-simple
+    revision: busybox
+  strategy:
+    name: kaniko
+    kind: ClusterBuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/kaniko-fast

--- a/test/e2e/validators.go
+++ b/test/e2e/validators.go
@@ -182,7 +182,7 @@ func validateBuildRunToSucceed(
 	// Ensure that a TaskRun has been created and is in pending or running state
 	if os.Getenv(EnvVarVerifyTektonObjects) == "true" {
 		Eventually(func() string {
-			taskRun, err := getTaskRun(f, testBuildRun)
+			taskRun, err := getTaskRun(testBuildRun)
 			if err != nil {
 				Logf("Retrieving TaskRun error: '%s'", err)
 				return ""
@@ -416,10 +416,9 @@ func buildRunTestData(ns string, identifier string, buildRunCRPath string) (*ope
 }
 
 // getTaskRun retrieve Tekton's Task based on BuildRun instance.
-func getTaskRun(
-	f *framework.Framework,
-	buildRun *buildv1alpha1.BuildRun,
-) (*v1beta1.TaskRun, error) {
+func getTaskRun(buildRun *buildv1alpha1.BuildRun) (*v1beta1.TaskRun, error) {
+	f := framework.Global
+
 	taskRunList := &v1beta1.TaskRunList{}
 	lbls := map[string]string{
 		buildv1alpha1.LabelBuild:    buildRun.Spec.BuildRef.Name,
@@ -437,4 +436,16 @@ func getTaskRun(
 		return &taskRunList.Items[len(taskRunList.Items)-1], nil
 	}
 	return nil, nil
+}
+
+func deleteBuildRun(buildRun *buildv1alpha1.BuildRun) error {
+	f := framework.Global
+
+	return f.Client.Delete(goctx.TODO(), buildRun)
+}
+
+func updateTaskRun(taskRun *v1beta1.TaskRun) error {
+	f := framework.Global
+
+	return f.Client.Update(goctx.TODO(), taskRun)
 }


### PR DESCRIPTION
Fixes #315 

The fix adds the annotation `buildrun.build.dev/uid` to the TaskRun. In the buildrun reconciler, this allows us to recognize if the TaskRun that we find is really for the BuildRun that we work on or is garbage from a previous BuildRun that the Kubernetes Garbage Collector has not yet deleted.

In my solution, I then delete the TaskRun explicitly and directly create the new TaskRun allowing the BuildRun creator to see its BuildRun to start as fast as possible.

An alternative strategy would be to wait for Kubernetes to do the deletion by polling or in a reconciliation loop. I am not in favor of this for two reasons:

1. If the garbage collector is busy, then this can take time (we had seen a few minutes)
2. Loops with an exit condition (TaskRun deleted by Kubernetes garbage collector) that is not under our control, is not a good approach imo as we would put pressure on our operator with that and probably slow it down.