### PR TITLE
Fix for issue #320

### DIFF
--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -104,13 +104,11 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			o := e.ObjectOld.(*v1beta1.TaskRun)
 			n := e.ObjectNew.(*v1beta1.TaskRun)
-			// Process an update event when the old TR resource is not yet started and the new TR resource is in Pending state.
-			// This allow us to catch the PENDING condition.Reason in the BuildRun
 
-			if n.Status.GetCondition(apis.ConditionSucceeded) != nil {
-				if o.Status.StartTime.IsZero() && n.Status.GetCondition(apis.ConditionSucceeded).Reason == pendingReason {
-					return true
-				}
+			// Process an update event when the old TR resource is not yet started and the new TR resource got a
+			// condition of the type Succeeded
+			if o.Status.StartTime.IsZero() && n.Status.GetCondition(apis.ConditionSucceeded) != nil {
+				return true
 			}
 
 			// Process an update event for every change in the condition.Reason between the old and new TR resource


### PR DESCRIPTION
Fix for issue #320

A TaskRun can jump from having no Conditions into
a Condition with any Reason. Usually it will be alway
get a PENDING Reason, but is not always the case.


I tested this manually. We need to improve our test cases for the integration with Tekton TaskRun, but we would first need to do some work around it(#322). Therefore Im ok with this PR not having a related test case. Just for the record:


```sh
$ k -n test-build get tr -w
NAME                     SUCCEEDED   REASON   STARTTIME   COMPLETIONTIME
kaniko-golang-buildrun
kaniko-golang-buildrun
kaniko-golang-buildrun   False       CouldntGetTask   0s
kaniko-golang-buildrun   False       CouldntGetTask   0s

$ k -n test-build get br -w
NAME                     SUCCEEDED   REASON   STARTTIME   COMPLETIONTIME
kaniko-golang-buildrun
kaniko-golang-buildrun
kaniko-golang-buildrun   False       failed to create task run pod "kaniko-golang-buildrun": Pod "kaniko-golang-buildrun-pod-2gppd" is invalid: spec.containers[2].resources.requests: Invalid value: "4Gi": must be less than or equal to ephemeral-storage limit. Maybe invalid TaskSpec   0s
```

Signed-off-by: Sascha Schwarze <schwarzs@de.ibm.com>