### PR TITLE
Add documentation for KANIKO_CONTAINER_IMAGE env var

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -258,6 +258,8 @@ Please consider the description of the attributes under `.spec.runtime`:
 > Specifying the runtime section will cause a `BuildRun` to push `spec.output.image` twice. First, the image produced by chosen `BuildStrategy` is pushed, and next it gets reused to construct the runtime-image, which is pushed again, overwriting `BuildStrategy` outcome.
 > Be aware, specially in situations where the image push action triggers automation steps. Since the same tag will be reused, you might need to take this in consideration when using runtime-images.
 
+Under the cover, the runtime image will be an additional step in the generated Task spec of the TaskRun. It uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to run a container build using the `gcr.io/kaniko-project/executor:v0.24.0` image. You can overwrite this image by adding the environment variable `KANIKO_CONTAINER_IMAGE` to the [build operator deployment](../deploy/operator.yaml).
+
 ## Using Finalizers
 
 The Build controller support Kubernetes finalizers in order to asynchronously delete resources. For the case of a Build instance with a particular annotation,


### PR DESCRIPTION
I am adding a sentence to the documentation about the `KANIKO_CONTAINER_IMAGE` environment variable that was added for the runtime image support, [Runtime Image Support #263](https://github.com/redhat-developer/build/pull/263).