### PR TITLE
Retrieve build in buildrun controller only to create taskrun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ build: $(OPERATOR)
 $(OPERATOR): vendor
 	go build $(GO_FLAGS) -o $(OPERATOR) cmd/manager/main.go
 
+.PHONY: build-plain
+build-plain: 
+	go build $(GO_FLAGS) -o $(OPERATOR) cmd/manager/main.go
+
 install-ginkgo:
 	go get -u github.com/onsi/ginkgo/ginkgo
 	go get -u github.com/onsi/gomega/...
@@ -124,6 +128,10 @@ crds:
 	@hack/crd.sh install
 
 local: crds build
+	OPERATOR_NAME=build-operator \
+	operator-sdk run --local --operator-flags="$(ZAP_FLAGS)"
+
+local-plain: build-plain
 	OPERATOR_NAME=build-operator \
 	operator-sdk run --local --operator-flags="$(ZAP_FLAGS)"
 


### PR DESCRIPTION
Fixes #329 

I changed the buildrun controller to retrieve the build only when it is in the code path to create the task run. This code path is written to be idempotent = if anything in this code path fails, then another reconciliation will not fail if parts of it (setting the labels or the buildSpec in the status) is done already.

Imo the code is now also more accurate because the build labels and buildspec in the status are set to the values that match those that are used to create the taskrun. The old code potentially set the fields to values that were not used to create the taskrun.

There was a test case already that verifies that the buildrun would fail if the build is not there even if the task run was already created. I changed this to reflect the new behavior.

I also noticed that we did not properly handle the scenario that the build controller is restarted (for example due to an updated container image in its deployment). After such a restart, the controller reconciles all buildruns. I added there two exit conditions:

1. I added the `CreateFunc` predicate function for the buildrun. A `CreateEvent` happens, when the build controller is started. I am filtering out those buildruns where the `LatestTaskRunRef` is already set in the status.
2. To prevent a second taskrun from being created, I added a block in the reconciler that notices that the `BuildSpec` is set in the status and then checks the `LatestTaskRunRef` again (there could be a race condition when the controller starts and queues many reconciles while we reconcile on a TaskRun update in parallel where we set the `LatestTaskRunRef`). If `LatestTaskRunRef` is nil, then a list call is done to check if there is really no one. We look for a taskrun with a matching label and also compare the UID in the owner reference to make sure we ignore an orphaned one from a previous buildrun that has not yet been garbage collected.

The change in the `updateBuildRunErrorStatus` function is the fix related to this comment in the issue description: *BTW: in case you noticed it, I was also surprised about the STARTTIME value when it failed. :-) But that's another small issue I will address.*