### PR TITLE
Remove leader-for-life HA mode

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
@@ -98,13 +97,6 @@ func main() {
 		os.Exit(1)
 	}
 	defer r.Unset()
-
-	// Become the leader before proceeding
-	err = leader.Become(ctx, "build-operator-lock")
-	if err != nil {
-		ctxlog.Error(ctx, err, "")
-		os.Exit(1)
-	}
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{


### PR DESCRIPTION
Fix issue: https://github.com/redhat-developer/build/issues/333

Now, we are using `leader-for-life` and `leader-for-lease`. But we just need `leader-for-lease` HA mode for operator. I have verified the situation when we delete below part:
```
err = leader.Become(ctx, "build-operator-lock")
	if err != nil {
		ctxlog.Error(ctx, err, "")
		os.Exit(1)
	}
```
Once the previous leader is not ready, such as `terminating` or something, other inactive pod will take over the leader.

I delete above part, build a new image `us.icr.io/coligo-serving/operator` and consume it. Everything works as my expected, below is the testing process:
- Check the leader 
```
root@jordan-0:/build# k get pod -n source-to-image -o wide
kubectl get pod -n source-to-image -o wide
NAME                              READY   STATUS    RESTARTS   AGE    IP              NODE            NOMINATED NODE   READINESS GATES
build-operator-57467bd6dc-6cck7   1/1     Running   0          15m    172.30.126.32   10.242.64.72    <none>           <none>
build-operator-57467bd6dc-c5tn6   1/1     Running   0          77m    172.30.252.48   10.242.128.66   <none>           <none>
build-operator-57467bd6dc-z6f94   1/1     Running   0          162m   172.30.18.247   10.242.0.19     <none>           <none>
root@jordan-0:/build# k logs build-operator-57467bd6dc-z6f94 -n source-to-image --all-containers
kubectl logs build-operator-57467bd6dc-z6f94 -n source-to-image --all-containers
{"level":"info","ts":1597214965.832229,"logger":"build","msg":"Operator Version: 0.0.1"}
{"level":"info","ts":1597214965.832294,"logger":"build","msg":"Go Version: go1.14.2"}
{"level":"info","ts":1597214965.8323126,"logger":"build","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1597214965.8323295,"logger":"build","msg":"Version of operator-sdk: v0.17.0"}
{"level":"info","ts":1597214971.5464182,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8383"}
{"level":"info","ts":1597214971.5467987,"logger":"build","msg":"Registering Components."}
{"level":"debug","ts":1597214971.5473092,"logger":"kubemetrics","msg":"Starting collecting operator types"}
{"level":"debug","ts":1597214971.5473413,"logger":"kubemetrics","msg":"Generating metric families","apiVersion":"build.dev/v1alpha1","kind":"BuildRun"}
{"level":"info","ts":1597214977.0570662,"logger":"build","msg":"Could not generate and serve custom resource metrics","error":"discovering resource information failed for BuildRun in build.dev/v1alpha1: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request"}
{"level":"debug","ts":1597214982.5645957,"logger":"k8sutil","msg":"Found namespace","Namespace":"source-to-image"}
{"level":"debug","ts":1597214982.5646713,"logger":"k8sutil","msg":"Found podname","Pod.Name":"build-operator-57467bd6dc-z6f94"}
{"level":"debug","ts":1597214982.5862465,"logger":"k8sutil","msg":"Found Pod","Pod.Namespace":"source-to-image","Pod.Name":"build-operator-57467bd6dc-z6f94"}
{"level":"debug","ts":1597214982.6200187,"logger":"metrics","msg":"Pods owner found","Kind":"Deployment","Name":"build-operator","Namespace":"source-to-image"}
{"level":"info","ts":1597214982.7286372,"logger":"metrics","msg":"Metrics Service object updated","Service.Name":"build-operator-metrics","Service.Namespace":"source-to-image"}
{"level":"info","ts":1597214988.2335455,"logger":"build","msg":"Could not create ServiceMonitor object","error":"unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request"}
{"level":"info","ts":1597214988.2337332,"logger":"build","msg":"Starting the Cmd."}
I0812 06:49:48.234024       1 leaderelection.go:242] attempting to acquire leader lease  default/build-operator-lock...
{"level":"info","ts":1597214988.2341378,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
I0812 09:15:31.534354       1 leaderelection.go:252] successfully acquired lease default/build-operator-lock
{"level":"debug","ts":1597223731.534476,"logger":"controller-runtime.manager.events","msg":"Normal","object":{"kind":"ConfigMap","namespace":"default","name":"build-operator-lock","uid":"723a1c84-2cf0-459f-be6f-078d30dbd17d","apiVersion":"v1","resourceVersion":"67697161"},"reason":"LeaderElection","message":"build-operator-57467bd6dc-z6f94_a71dbe96-0a3c-48f1-bb03-ab1adae74432 became leader"}
{"level":"info","ts":1597223731.5347116,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"buildrun-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1597223731.5347936,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"buildstrategy-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1597223731.534849,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"build-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1597223731.5346382,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"clusterbuildstrategy-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1597223731.63567,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"buildrun-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1597223731.6361442,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"buildstrategy-controller"}
```
`build-operator-57467bd6dc-z6f94` is the leader and it's running on `10.242.0.19` node which is in `eu-gb-1` zone.

- Make `eu-gh-1` zone is un available
```
root@jordan-0:/build# k get nodes
kubectl get nodes
NAME            STATUS     ROLES    AGE    VERSION
10.242.0.19     NotReady   <none>   6d7h   v1.17.9+IKS
10.242.0.25     NotReady   <none>   23d    v1.17.7+IKS
10.242.0.81     NotReady   <none>   8d     v1.17.9+IKS
10.242.128.66   Ready      <none>   27d    v1.17.7+IKS
10.242.128.80   Ready      <none>   8d     v1.17.9+IKS
10.242.128.96   Ready      <none>   6d7h   v1.17.9+IKS
10.242.64.102   Ready      <none>   8d     v1.17.9+IKS
10.242.64.63    Ready      <none>   27d    v1.17.7+IKS
10.242.64.72    Ready      <none>   6d7h   v1.17.9+IKS
```
- Check the status of operator pods
```
root@jordan-0:/build# k get pod -n source-to-image -o wide -w
kubectl get pod -n source-to-image -o wide -w
NAME                              READY   STATUS    RESTARTS   AGE    IP              NODE            NOMINATED NODE   READINESS GATES
build-operator-57467bd6dc-6cck7   1/1     Running   0          29m    172.30.126.32   10.242.64.72    <none>           <none>
build-operator-57467bd6dc-c5tn6   1/1     Running   0          91m    172.30.252.48   10.242.128.66   <none>           <none>
build-operator-57467bd6dc-z6f94   1/1     Running   0          176m   172.30.18.247   10.242.0.19     <none>           <none>
build-operator-57467bd6dc-z6f94   1/1     Terminating   0          179m   172.30.18.247   10.242.0.19     <none>           <none>
build-operator-57467bd6dc-9sbdl   0/1     Pending       0          0s     <none>          <none>          <none>           <none>
build-operator-57467bd6dc-9sbdl   0/1     Pending       0          0s     <none>          <none>          <none>           <none>
```
- Check if the leader has been taken over or not
```
^Croot@jordan-0:/build# logs build-operator-57467bd6dc-6cck7 -n source-to-image --all-containers
kubectl logs build-operator-57467bd6dc-6cck7 -n source-to-image --all-containers
{"level":"info","ts":1597223725.893488,"logger":"build","msg":"Operator Version: 0.0.1"}
{"level":"info","ts":1597223725.8935952,"logger":"build","msg":"Go Version: go1.14.2"}
{"level":"info","ts":1597223725.8936331,"logger":"build","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1597223725.893663,"logger":"build","msg":"Version of operator-sdk: v0.17.0"}
{"level":"info","ts":1597223731.41405,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8383"}
{"level":"info","ts":1597223731.414741,"logger":"build","msg":"Registering Components."}
{"level":"debug","ts":1597223731.415897,"logger":"kubemetrics","msg":"Starting collecting operator types"}
{"level":"debug","ts":1597223731.4159784,"logger":"kubemetrics","msg":"Generating metric families","apiVersion":"build.dev/v1alpha1","kind":"BuildStrategy"}
{"level":"info","ts":1597223736.9270194,"logger":"build","msg":"Could not generate and serve custom resource metrics","error":"discovering resource information failed for BuildStrategy in build.dev/v1alpha1: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request"}
{"level":"debug","ts":1597223742.4381528,"logger":"k8sutil","msg":"Found namespace","Namespace":"source-to-image"}
{"level":"debug","ts":1597223742.4382958,"logger":"k8sutil","msg":"Found podname","Pod.Name":"build-operator-57467bd6dc-6cck7"}
{"level":"debug","ts":1597223742.4686573,"logger":"k8sutil","msg":"Found Pod","Pod.Namespace":"source-to-image","Pod.Name":"build-operator-57467bd6dc-6cck7"}
{"level":"debug","ts":1597223742.5053635,"logger":"metrics","msg":"Pods owner found","Kind":"Deployment","Name":"build-operator","Namespace":"source-to-image"}
{"level":"info","ts":1597223742.6811185,"logger":"metrics","msg":"Metrics Service object updated","Service.Name":"build-operator-metrics","Service.Namespace":"source-to-image"}
{"level":"info","ts":1597223748.1882496,"logger":"build","msg":"Could not create ServiceMonitor object","error":"unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request"}
{"level":"info","ts":1597223748.1884096,"logger":"build","msg":"Starting the Cmd."}
I0812 09:15:48.188779       1 leaderelection.go:242] attempting to acquire leader lease  default/build-operator-lock...
{"level":"info","ts":1597223748.189264,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
I0812 09:36:35.738036       1 leaderelection.go:252] successfully acquired lease default/build-operator-lock
{"level":"info","ts":1597224995.7385085,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"clusterbuildstrategy-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1597224995.7386932,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"buildrun-controller","source":"kind source: /, Kind="}
{"level":"debug","ts":1597224995.7385375,"logger":"controller-runtime.manager.events","msg":"Normal","object":{"kind":"ConfigMap","namespace":"default","name":"build-operator-lock","uid":"723a1c84-2cf0-459f-be6f-078d30dbd17d","apiVersion":"v1","resourceVersion":"67719833"},"reason":"LeaderElection","message":"build-operator-57467bd6dc-6cck7_89e2a681-a380-4b6c-b934-d474acef6dca became leader"}
{"level":"info","ts":1597224995.7391448,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"build-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1597224995.739031,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"buildstrategy-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1597224995.8413842,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"buildstrategy-controller"}
{"level":"info","ts":1597224995.84154,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"clusterbuildstrategy-controller"}
{"level":"info","ts":1597224995.842286,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"buildrun-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1597224995.943054,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"build-controller"}
```
Leader is taken over by `build-operator-57467bd6dc-6cck7` pod.