### PR TITLE
Make timeouts within e2e tests configurable

### DIFF
--- a/HACK.md
+++ b/HACK.md
@@ -80,6 +80,7 @@ The following table contains a set of environment variables that control the beh
 | `TEST_E2E_FLAGS`                | `-failFast -flakeAttempts=2 -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=20m -trace -v` | Ginkgo flags. See all Ginkgo flags here: [The Ginkgo CLI](https://onsi.github.io/ginkgo/#the-ginkgo-cli). Especially of interest are `--focus` and `--skip` to run selective tests. |
 | `TEST_E2E_CREATE_GLOBALOBJECTS` | `true`                                                                                           | Boolean, if `false`, the custom resource definitions and (cluster) build strategies are not created and deleted by the e2e test code |
 | `TEST_E2E_OPERATOR`             | `start_local`                                                                                    | String with allowed values `start_local` (will start the local operator and print its logs add the end of the test run) and `managed_outside` (will assume that the operator is running through whatever means) |
+| `TEST_E2E_TIMEOUT_MULTIPLIER`   | `1`                                                                                              | Multiplier for timeouts in the e2e tests to run them on slower systems. |
 | `TEST_E2E_VERIFY_TEKTONOBJECTS` | `true`                                                                                           | Boolean, if false, the verification code will not try to verify the TaskRun object status |
 
 The following table contains a list of environment variables you that will override specific paths under the **Build** CRD.

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ TEST_E2E_CREATE_GLOBALOBJECTS ?= true
 # E2E test verify Tekton objects
 TEST_E2E_VERIFY_TEKTONOBJECTS ?= true
 
+# E2E test timeout multiplier
+TEST_E2E_TIMEOUT_MULTIPLIER ?= 1
+
 # test repository to store images build during end-to-end tests
 TEST_IMAGE_REPO ?= quay.io/redhat-developer/build-e2e
 # test container registyr secret name
@@ -120,6 +123,7 @@ test-e2e-plain:
 	TEST_E2E_OPERATOR=${TEST_E2E_OPERATOR} \
 	TEST_E2E_CREATE_GLOBALOBJECTS=${TEST_E2E_CREATE_GLOBALOBJECTS} \
 	TEST_E2E_SERVICEACCOUNT_NAME=${TEST_E2E_SERVICEACCOUNT_NAME} \
+	TEST_E2E_TIMEOUT_MULTIPLIER=${TEST_E2E_TIMEOUT_MULTIPLIER} \
 	TEST_E2E_VERIFY_TEKTONOBJECTS=${TEST_E2E_VERIFY_TEKTONOBJECTS} \
 	ginkgo ${TEST_E2E_FLAGS} test/e2e
 


### PR DESCRIPTION
When running the e2e tests on slow systems (like my machine) I sometimes get timeouts for some e2e test cases (specifically because it is taking longer to download container images as my internet connection is not rocket fast).

Beside that we run a few of the e2e tests also to continuously verify the availability of our service. And then those tests sometimes fail because the overall system load makes things slower.

I am adding an environment variable that allows to multiply the 